### PR TITLE
fix relative path issue in provider_test.go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ coverage: vendor
 .PHONY: coverage
 
 acceptance:
+	TF_ACC_CONFIG_PATH=$(shell pwd)	\
 	TF_ACC=true go test -v -timeout=1200s -cover github.com/HewlettPackard/hpegl-vmaas-terraform-resources/internal/acceptance_test
 
 build: vendor $(NAME)

--- a/internal/acceptance_test/provider_test.go
+++ b/internal/acceptance_test/provider_test.go
@@ -4,8 +4,6 @@ package acceptancetest
 
 import (
 	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	testutils "github.com/HewlettPackard/hpegl-vmaas-terraform-resources/pkg/test-utils"
@@ -45,11 +43,8 @@ func TestProvider(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	// nolint
-	_, b, _, _ := runtime.Caller(0)
-	// Root folder of this project
-	d := filepath.Join(filepath.Dir(b), "../..")
-	libUtils.ReadAccConfig(d)
+	// TF_ACC_CONFIG_PATH set in make acceptance
+	libUtils.ReadAccConfig(os.Getenv("TF_ACC_CONFIG_PATH"))
 	m.Run()
 	os.Exit(0)
 }


### PR DESCRIPTION
Using env variable as path to root directory so there is not an issue when the tests are copied to the terraform-provider. Set in make acceptance command.

This is one possible solution to this issue but we would like your opinion on it. Do you think this is ok? Another solution that is being considered is to only have one env var that contains the path and the name of the env/config file that you would like to test to reduce the number of env vars.  eg. ../../prod    
We would then write some code to separate the path from the config file name.
Let us know your thoughts.