### PR TITLE
Doc related changes for Router

### DIFF
--- a/examples/resources/hpegl_vmaas_router/nsx_t_tier0.tf
+++ b/examples/resources/hpegl_vmaas_router/nsx_t_tier0.tf
@@ -1,0 +1,42 @@
+# (C) Copyright 2021 Hewlett Packard Enterprise Development LP
+
+# Tier0 router
+resource "hpegl_vmaas_router" "tf_tier0" {
+  name     = "tf_tier0_gateway"
+  enable   = true
+  group_id = "shared"
+  tier0_config {
+    bgp {
+      ecmp             = true
+      enable_bgp       = true
+      inter_sr_ibgp    = true
+      local_as_num     = 65000
+      multipath_relax  = true
+      restart_mode     = "HELPER_ONLY"
+      restart_time     = 180
+      stale_route_time = 600
+    }
+    route_redistribution_tier0 {
+      tier0_dns_forwarder_ip   = false
+      tier0_external_interface = true
+      tier0_ipsec_local_ip     = false
+      tier0_loopback_interface = true
+      tier0_nat                = true
+      tier0_segment            = true
+      tier0_service_interface  = true
+      tier0_static             = true
+    }
+    route_redistribution_tier1 {
+       tier1_dns_forwarder_ip     = false
+       tier1_service_interface    = true
+       tier1_ipsec_local_endpoint = false
+       tier1_lb_snat              = false
+       tier1_lb_vip               = false
+       tier1_nat                  = false
+       tier1_segment              = true
+       tier1_static               = false
+    }
+    fail_over = "NON_PREEMPTIVE"
+    ha_mode   = "ACTIVE_STANDBY"
+  }
+}

--- a/examples/resources/hpegl_vmaas_router/nsx_t_tier1.tf
+++ b/examples/resources/hpegl_vmaas_router/nsx_t_tier1.tf
@@ -1,0 +1,20 @@
+# (C) Copyright 2021 Hewlett Packard Enterprise Development LP
+
+# Tier1 router
+resource "hpegl_vmaas_router" "tf_tier1" {
+  name     = "tf_tier1"
+  enable   = true
+  group_id = "shared"
+  tier1_config {
+      tier0_gateway = data.hpegl_vmaas_router.tier0_router.provider_id
+    route_advertisement {
+      tier1_connected = true
+      tier1_static_routes = false
+      tier1_dns_forwarder_ip = true
+      tier1_lb_vip = false
+      tier1_nat = false
+      tier1_lb_snat = false
+      tier1_ipsec_local_endpoint = true
+    }
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/HewlettPackard/hpegl-vmaas-terraform-resources
 go 1.17
 
 require (
-	github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk v0.1.1-0.20211019050313-8ddf0359a975
+	github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk v0.1.1-0.20211020180719-452f9fda0acc
 	github.com/golang/mock v1.6.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk v0.1.1-0.20211018053846-acbc5d8
 github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk v0.1.1-0.20211018053846-acbc5d80cffe/go.mod h1:ZvrEbVcIZndDXpYV4OyAVKr0Bs1bKmpXXa4fvW8cKz0=
 github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk v0.1.1-0.20211019050313-8ddf0359a975 h1:d+6XxtPGze7qISSFrfBX5ACeaNma3S+OsqlOx1vfpBk=
 github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk v0.1.1-0.20211019050313-8ddf0359a975/go.mod h1:ZvrEbVcIZndDXpYV4OyAVKr0Bs1bKmpXXa4fvW8cKz0=
+github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk v0.1.1-0.20211020180719-452f9fda0acc h1:d1VrYPwxAK+rv9JiZUvnmqenOPCdAo3m0yz7r+PKmdY=
+github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk v0.1.1-0.20211020180719-452f9fda0acc/go.mod h1:ZvrEbVcIZndDXpYV4OyAVKr0Bs1bKmpXXa4fvW8cKz0=
 github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=

--- a/internal/cmp/router.go
+++ b/internal/cmp/router.go
@@ -128,6 +128,7 @@ func (r *router) routerAlignRouterRequest(ctx context.Context, meta interface{},
 		routerReq.NetworkRouter.Config.CreateRouterTier0Config.RouteRedistributionTier1.RouteAdvertisement =
 			routerReq.NetworkRouter.TfTier1Config.TfRouteAdvertisement
 		routerReq.NetworkRouter.Config.EdgeCluster = routerReq.NetworkRouter.TfTier1Config.TfEdgeCluster
+		routerReq.NetworkRouter.Config.FailOver = routerReq.NetworkRouter.TfTier1Config.TfFailOver
 		routerReq.NetworkRouter.Config.Tier0Gateways = routerReq.NetworkRouter.TfTier1Config.TfTier0Gateways
 		queryParam[nameKey] = tier1GatewayType
 	}

--- a/internal/resources/resource_router.go
+++ b/internal/resources/resource_router.go
@@ -51,6 +51,8 @@ func Router() *schema.Resource {
 		CreateContext: routerCreateContext,
 		UpdateContext: routerUpdateContext,
 		DeleteContext: routerDeleteContext,
+		Description: `Router resource facilitates creating,
+		updating and deleting NSX-T Tier0/Tier1 Network Routers.`,
 	}
 }
 

--- a/internal/resources/schemas/router_schemas.go
+++ b/internal/resources/schemas/router_schemas.go
@@ -231,6 +231,14 @@ func RouterTier1ConfigSchema() *schema.Schema {
 					Optional:    true,
 					Description: "Edge Cluster",
 				},
+				"fail_over": {
+					Type:     schema.TypeString,
+					Required: true,
+					ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{
+						"NON_PREEMPTIVE", "PREEMPTIVE",
+					}, false)),
+					Description: "Failover. Available values are 'PREEMPTIVE' or 'NON_PREEMPTIVE'",
+				},
 				"route_advertisement": {
 					Type:     schema.TypeList,
 					Optional: true,

--- a/templates/resources/vmaas_router.md.tmpl
+++ b/templates/resources/vmaas_router.md.tmpl
@@ -1,0 +1,31 @@
+---
+layout: ""
+page_title: "hpegl_vmaas_router Resource - vmaas-terraform-resources"
+description: |-
+  {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+---
+
+# Resource hpegl_vmaas_router
+
+{{ .Description | trimspace }}
+`hpegl_vmaas_router` resource supports NSX-T Tier0/Tier1 network router creation.
+
+For creating an NSX-T Tier0/Tier1 network router please refer following examples.
+
+-> NSX-T Tier0 & Tier1 router are considered as different instances. So you can create either Tier0 or Tier1 at a given time.
+
+## Example usage for creating NSX-T Tier0 Network router with all possible attributes
+
+-> Incase of NSX-T Tier0 network router creation, `fail_over` attribute is applicable only if `ha_mode` attribute is
+set to `ACTIVE_STANDBY`.
+
+{{tffile "examples/resources/hpegl_vmaas_router/nsx_t_tier0.tf"}}
+
+## Example usage for creating NSX-T Tier1 Network router with all possible attributes
+
+-> Incase of NSX-T Tier1 network router creation, `fail_over` attribute is applicable only if `edge_cluster` attribute
+is set.
+
+{{tffile "examples/resources/hpegl_vmaas_router/nsx_t_tier1.tf"}}
+
+{{ .SchemaMarkdown | trimspace }}


### PR DESCRIPTION
Made changes for Docs Generation for Routers
Added 'fail_over` attribute in Tier1 schema. this attribute is applicable only when edge_cluster attribute is set.

`Note: The document doesn't talk about the open issues we currently have related to Router such as "EdgeCluster" fetching mechanism(as we dont have CMP APIs to fetch EdgeCluster yet. Currently examples also doesnt cover that. These can be updated once the APIs are available in 5.2.12`

attaching the Generated docs for reference.

```
`---
layout: ""
page_title: "hpegl_vmaas_router Resource - vmaas-terraform-resources"
description: |-
    
---

# Resource hpegl_vmaas_router


`hpegl_vmaas_router` resource supports NSX-T Tier0/Tier1 network router creation.

For creating an NSX-T Tier0/Tier1 network router please refer following examples.

-> NSX-T Tier0 & Tier1 router are considered as different instances. So you can create either Tier0 or Tier1 at a given time.

## Example usage for creating NSX-T Tier0 Network router with all possible attributes

-> Incase of NSX-T Tier0 network router creation, `fail_over` attribute is applicable only if `ha_mode` attribute is
set to `ACTIVE_STANDBY`.

```terraform
# (C) Copyright 2021 Hewlett Packard Enterprise Development LP

# Tier0 router
resource "hpegl_vmaas_router" "tf_tier0" {
  name     = "tf_tier0_gateway"
  enable   = true
  group_id = "shared"
  tier0_config {
    bgp {
      ecmp             = true
      enable_bgp       = true
      inter_sr_ibgp    = true
      local_as_num     = 65000
      multipath_relax  = true
      restart_mode     = "HELPER_ONLY"
      restart_time     = 180
      stale_route_time = 600
    }
    route_redistribution_tier0 {
      tier0_dns_forwarder_ip   = false
      tier0_external_interface = true
      tier0_ipsec_local_ip     = false
      tier0_loopback_interface = true
      tier0_nat                = true
      tier0_segment            = true
      tier0_service_interface  = true
      tier0_static             = true
    }
    route_redistribution_tier1 {
      tier1_dns_forwarder_ip     = false
      tier1_service_interface    = true
      tier1_ipsec_local_endpoint = false
      tier1_lb_snat              = false
      tier1_lb_vip               = false
      tier1_nat                  = false
      tier1_segment              = true
      tier1_static               = false
    }
    fail_over = "NON_PREEMPTIVE"
    ha_mode   = "ACTIVE_STANDBY"
  }
}
```

## Example usage for creating NSX-T Tier1 Network router with all possible attributes

-> Incase of NSX-T Tier1 network router creation, `fail_over` attribute is applicable only if `edge_cluster` attribute
is set.

```terraform
# (C) Copyright 2021 Hewlett Packard Enterprise Development LP

# Tier1 router
resource "hpegl_vmaas_router" "tf_tier1" {
  name     = "tf_tier1"
  enable   = true
  group_id = "shared"
  tier1_config {
    tier0_gateway = data.hpegl_vmaas_router.tier0_router.provider_id
    route_advertisement {
      tier1_connected            = true
      tier1_static_routes        = false
      tier1_dns_forwarder_ip     = true
      tier1_lb_vip               = false
      tier1_nat                  = false
      tier1_lb_snat              = false
      tier1_ipsec_local_endpoint = true
    }
  }
}
```

<!-- schema generated by tfplugindocs -->
## Schema

### Required

- **group_id** (String) Group ID. Available values are either 'Shared' or ID fetched from hpegl_vmaas_group
- **name** (String) Network router name

### Optional

- **enable** (Boolean) Can be used to enable/disable the network router
- **id** (String) The ID of this resource.
- **tier0_config** (Block List, Max: 1) Tier0 Gateway configuration (see [below for nested schema](#nestedblock--tier0_config))
- **tier1_config** (Block List, Max: 1) Tier1 Gateway configuration (see [below for nested schema](#nestedblock--tier1_config))

### Read-Only

- **network_server_id** (Number) NSX-T Integration ID
- **type_id** (Number) Network router type ID.

<a id="nestedblock--tier0_config"></a>
### Nested Schema for `tier0_config`

Required:

- **bgp** (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--tier0_config--bgp))
- **fail_over** (String) Failover. Available values are 'PREEMPTIVE' or 'NON_PREEMPTIVE'
- **ha_mode** (String) HA Mode. Available values are 'ACTIVE_ACTIVE' or 'ACTIVE_STANDBY'

Optional:

- **route_redistribution_tier0** (Block List, Max: 1) (see [below for nested schema](#nestedblock--tier0_config--route_redistribution_tier0))
- **route_redistribution_tier1** (Block List, Max: 1) (see [below for nested schema](#nestedblock--tier0_config--route_redistribution_tier1))

<a id="nestedblock--tier0_config--bgp"></a>
### Nested Schema for `tier0_config.bgp`

Required:

- **local_as_num** (Number) Local AS Number
- **restart_mode** (String) Graceful Restart
- **restart_time** (Number) Graceful Restart Timer
- **stale_route_time** (Number) Graceful Restart Stale Timer

Optional:

- **ecmp** (Boolean) ECMP
- **enable_bgp** (Boolean)
- **inter_sr_ibgp** (Boolean) Inter SR iBGP
- **multipath_relax** (Boolean) Multipath Relax


<a id="nestedblock--tier0_config--route_redistribution_tier0"></a>
### Nested Schema for `tier0_config.route_redistribution_tier0`

Optional:

- **tier0_dns_forwarder_ip** (Boolean) DNS Forwarder IP
- **tier0_external_interface** (Boolean) External Interface Subnet
- **tier0_ipsec_local_ip** (Boolean) IP Sec Local IP
- **tier0_loopback_interface** (Boolean) Loopback Interface Subnet
- **tier0_nat** (Boolean) NAT IP
- **tier0_segment** (Boolean) Connected Segment
- **tier0_service_interface** (Boolean) Service Interface Subnet
- **tier0_static** (Boolean) Static Routes


<a id="nestedblock--tier0_config--route_redistribution_tier1"></a>
### Nested Schema for `tier0_config.route_redistribution_tier1`

Optional:

- **tier1_dns_forwarder_ip** (Boolean) DNS Forwarder IP
- **tier1_ipsec_local_endpoint** (Boolean) IPSec Local Endpoint
- **tier1_lb_snat** (Boolean) LB SNAT IP
- **tier1_lb_vip** (Boolean) LB VIP
- **tier1_nat** (Boolean) NAT IP
- **tier1_segment** (Boolean) Connected Segment
- **tier1_service_interface** (Boolean) Service Interface Subnet
- **tier1_static** (Boolean) Static Routes



<a id="nestedblock--tier1_config"></a>
### Nested Schema for `tier1_config`

Optional:

- **edge_cluster** (String) Edge Cluster
- **route_advertisement** (Block List, Max: 1) (see [below for nested schema](#nestedblock--tier1_config--route_advertisement))
- **tier0_gateway** (String) Provider ID of the Tier0 Gateway. Use Tier0 Router's  .provider_id  here.

<a id="nestedblock--tier1_config--route_advertisement"></a>
### Nested Schema for `tier1_config.route_advertisement`

Optional:

- **tier1_connected** (Boolean) Connected Routes
- **tier1_dns_forwarder_ip** (Boolean) DNS Forwarder IP Routes
- **tier1_ipsec_local_endpoint** (Boolean) IPSec Local Endpoint
- **tier1_lb_snat** (Boolean) LB SNAT IP Routes
- **tier1_lb_vip** (Boolean) LB VIP Routes
- **tier1_nat** (Boolean) NAT IPs
- **tier1_static_routes** (Boolean) Static Routes`
```