### PR TITLE
Fixes for Acceptance Test of Tier1

### DIFF
--- a/integ.yaml
+++ b/integ.yaml
@@ -74,6 +74,7 @@ vmaas:
         enable: true
         group_id: shared
         tier1_config:
+          fail_over: NON_PREEMPTIVE
           route_advertisement:
             tier1_connected: true
             tier1_static_routes: false

--- a/internal/acceptance_test/resource_router_tier1_test.go
+++ b/internal/acceptance_test/resource_router_tier1_test.go
@@ -91,6 +91,7 @@ func testAccResourceTier1Router() string {
 		enable   = %t
 		group_id = "%s"
 		tier1_config {
+			fail_over = "%s"
 			route_advertisement {
 				tier1_connected = %t
 				tier1_static_routes = %t
@@ -107,6 +108,7 @@ func testAccResourceTier1Router() string {
 		r.Int63n(999999),
 		viper.GetBool("vmaas.resource.router.tier1.enable"),
 		viper.GetString("vmaas.resource.router.tier1.group_id"),
+		viper.GetString("vmaas.resource.router.tier1.tier1_config.fail_over"),
 		viper.GetBool("vmaas.resource.router.tier1.tier1_config.route_advertisement.tier1_connected"),
 		viper.GetBool("vmaas.resource.router.tier1.tier1_config.route_advertisement.tier1_static_routes"),
 		viper.GetBool("vmaas.resource.router.tier1.tier1_config.route_advertisement.tier1_dns_forwarder_ip"),


### PR DESCRIPTION
fail_over  is the new field that is added to Tier1 Router. Fixing acceptance test for the same.


```
Running tool: /usr/local/go/bin/go test -timeout 900s -run ^TestVmaasRouterTier1Plan$ github.com/HewlettPackard/hpegl-vmaas-terraform-resources/internal/acceptance_test

ok  	github.com/HewlettPackard/hpegl-vmaas-terraform-resources/internal/acceptance_test	1.054s

Running tool: /usr/local/go/bin/go test -timeout 900s -run ^TestAccResourceTier1RouterCreate$ github.com/HewlettPackard/hpegl-vmaas-terraform-resources/internal/acceptance_test

ok  	github.com/HewlettPackard/hpegl-vmaas-terraform-resources/internal/acceptance_test	(cached)
```