### PR TITLE
Terraform Resource changes for Router Firewall Groups

### DIFF
--- a/examples/resources/hpegl_vmaas_router_firewall_rule_group/resource.tf
+++ b/examples/resources/hpegl_vmaas_router_firewall_rule_group/resource.tf
@@ -1,0 +1,9 @@
+# (C) Copyright 2021 Hewlett Packard Enterprise Development LP
+
+resource "hpegl_vmaas_router_firewall_rule_group" "tf_router_firewall_rule_group" {
+  name        = "tf_router_firewall_group"
+  router_id   = data.hpegl_vmaas_router.tf_router.id
+  description = "Router Firewall rule group created via terraform"
+  priority = 120
+  group_layer = "LocalGatewayRules"
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/HewlettPackard/hpegl-vmaas-terraform-resources
 go 1.17
 
 require (
-	github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk v0.1.1-0.20211109091623-e30373323db7
+	github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk v0.1.1-0.20211110054614-0244d6a25a42
 	github.com/golang/mock v1.6.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk v0.1.1-0.20211109090511-1145498
 github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk v0.1.1-0.20211109090511-11454982448b/go.mod h1:QqQ2OwCQ1qmsMPscU2Y5MeLJP3Q5BPeaTE13s6hu7I8=
 github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk v0.1.1-0.20211109091623-e30373323db7 h1:ha+k9zTCnVRA1uMBKEL894Q3j+wCsn41RSk497ngXYY=
 github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk v0.1.1-0.20211109091623-e30373323db7/go.mod h1:QqQ2OwCQ1qmsMPscU2Y5MeLJP3Q5BPeaTE13s6hu7I8=
+github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk v0.1.1-0.20211110054614-0244d6a25a42 h1:cAIItsqgwTBETmTDPFZzs7PkGm2MdDnhmGCTEopge5U=
+github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk v0.1.1-0.20211110054614-0244d6a25a42/go.mod h1:QqQ2OwCQ1qmsMPscU2Y5MeLJP3Q5BPeaTE13s6hu7I8=
 github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=

--- a/internal/cmp/client.go
+++ b/internal/cmp/client.go
@@ -7,28 +7,29 @@ import apiClient "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/client"
 // Client is the cmp client which will implements all the
 // functions in interface.go
 type Client struct {
-	Instance         Resource
-	InstanceClone    Resource
-	Router           Resource
-	ResNetwork       Resource
-	RouterNat        Resource
-	Network          DataSource
-	NetworkType      DataSource
-	NetworkPool      DataSource
-	Plan             DataSource
-	Group            DataSource
-	Cloud            DataSource
-	ResourcePool     DataSource
-	Layout           DataSource
-	Datastore        DataSource
-	PowerSchedule    DataSource
-	Template         DataSource
-	Environment      DataSource
-	NetworkInterface DataSource
-	CloudFolder      DataSource
-	DSRouter         DataSource
-	DSDomain         DataSource
-	NetworkProxy     DataSource
+	Instance                Resource
+	InstanceClone           Resource
+	Router                  Resource
+	ResNetwork              Resource
+	RouterNat               Resource
+	RouterFirewallRuleGroup Resource
+	Network                 DataSource
+	NetworkType             DataSource
+	NetworkPool             DataSource
+	Plan                    DataSource
+	Group                   DataSource
+	Cloud                   DataSource
+	ResourcePool            DataSource
+	Layout                  DataSource
+	Datastore               DataSource
+	PowerSchedule           DataSource
+	Template                DataSource
+	Environment             DataSource
+	NetworkInterface        DataSource
+	CloudFolder             DataSource
+	DSRouter                DataSource
+	DSDomain                DataSource
+	NetworkProxy            DataSource
 }
 
 // NewClient returns configured client
@@ -46,20 +47,21 @@ func NewClient(client *apiClient.APIClient, cfg apiClient.Configuration) *Client
 			&apiClient.NetworksAPIService{Client: client, Cfg: cfg},
 			&apiClient.RouterAPIService{Client: client, Cfg: cfg},
 		),
-		Router:        newRouter(&apiClient.RouterAPIService{Client: client, Cfg: cfg}),
-		RouterNat:     newRouterNat(&apiClient.RouterAPIService{Client: client, Cfg: cfg}),
-		Network:       newNetwork(&apiClient.NetworksAPIService{Client: client, Cfg: cfg}),
-		NetworkType:   newNetworkType(&apiClient.NetworksAPIService{Client: client, Cfg: cfg}),
-		NetworkPool:   newNetworkPool(&apiClient.NetworksAPIService{Client: client, Cfg: cfg}),
-		Plan:          newPlan(&apiClient.PlansAPIService{Client: client, Cfg: cfg}),
-		Group:         newGroup(&apiClient.GroupsAPIService{Client: client, Cfg: cfg}),
-		Layout:        newLayout(&apiClient.LibraryAPIService{Client: client, Cfg: cfg}),
-		Cloud:         newCloud(&apiClient.CloudsAPIService{Client: client, Cfg: cfg}),
-		ResourcePool:  newResourcePool(&apiClient.CloudsAPIService{Client: client, Cfg: cfg}),
-		Datastore:     newDatastore(&apiClient.CloudsAPIService{Client: client, Cfg: cfg}),
-		PowerSchedule: newPowerSchedule(&apiClient.PowerSchedulesAPIService{Client: client, Cfg: cfg}),
-		Template:      newTemplate(&apiClient.VirtualImagesAPIService{Client: client, Cfg: cfg}),
-		Environment:   newEnvironment(&apiClient.EnvironmentAPIService{Client: client, Cfg: cfg}),
+		Router:                  newRouter(&apiClient.RouterAPIService{Client: client, Cfg: cfg}),
+		RouterNat:               newRouterNat(&apiClient.RouterAPIService{Client: client, Cfg: cfg}),
+		RouterFirewallRuleGroup: newRouterFirewallRuleGroup(&apiClient.RouterAPIService{Client: client, Cfg: cfg}),
+		Network:                 newNetwork(&apiClient.NetworksAPIService{Client: client, Cfg: cfg}),
+		NetworkType:             newNetworkType(&apiClient.NetworksAPIService{Client: client, Cfg: cfg}),
+		NetworkPool:             newNetworkPool(&apiClient.NetworksAPIService{Client: client, Cfg: cfg}),
+		Plan:                    newPlan(&apiClient.PlansAPIService{Client: client, Cfg: cfg}),
+		Group:                   newGroup(&apiClient.GroupsAPIService{Client: client, Cfg: cfg}),
+		Layout:                  newLayout(&apiClient.LibraryAPIService{Client: client, Cfg: cfg}),
+		Cloud:                   newCloud(&apiClient.CloudsAPIService{Client: client, Cfg: cfg}),
+		ResourcePool:            newResourcePool(&apiClient.CloudsAPIService{Client: client, Cfg: cfg}),
+		Datastore:               newDatastore(&apiClient.CloudsAPIService{Client: client, Cfg: cfg}),
+		PowerSchedule:           newPowerSchedule(&apiClient.PowerSchedulesAPIService{Client: client, Cfg: cfg}),
+		Template:                newTemplate(&apiClient.VirtualImagesAPIService{Client: client, Cfg: cfg}),
+		Environment:             newEnvironment(&apiClient.EnvironmentAPIService{Client: client, Cfg: cfg}),
 		NetworkInterface: newNetworkInterface(&apiClient.CloudsAPIService{Client: client, Cfg: cfg},
 			&apiClient.ProvisioningAPIService{Client: client, Cfg: cfg}),
 		CloudFolder:  newCloudFolder(&apiClient.CloudsAPIService{Client: client, Cfg: cfg}),

--- a/internal/cmp/constants.go
+++ b/internal/cmp/constants.go
@@ -18,6 +18,7 @@ const (
 	// retry related constants
 	maxTimeout = time.Hour * 2
 	// router consts
-	tier0GatewayType = "NSX-T Tier-0 Gateway"
-	tier1GatewayType = "NSX-T Tier-1 Gateway"
+	tier0GatewayType             = "NSX-T Tier-0 Gateway"
+	tier1GatewayType             = "NSX-T Tier-1 Gateway"
+	routerFirewallExternalPolicy = "GatewayPolicy"
 )

--- a/internal/cmp/router_firewall_rule_group.go
+++ b/internal/cmp/router_firewall_rule_group.go
@@ -1,0 +1,105 @@
+// (C) Copyright 2021 Hewlett Packard Enterprise Development LP
+
+package cmp
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/client"
+	"github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/models"
+	"github.com/HewlettPackard/hpegl-vmaas-terraform-resources/internal/utils"
+	"github.com/tshihad/tftags"
+)
+
+type routerFirewallRuleGroup struct {
+	routerFirewallRuleGroupClient *client.RouterAPIService
+}
+
+func newRouterFirewallRuleGroup(routerFirewallRuleGroupClient *client.RouterAPIService) *routerFirewallRuleGroup {
+	return &routerFirewallRuleGroup{
+		routerFirewallRuleGroupClient: routerFirewallRuleGroupClient,
+	}
+}
+
+func (r *routerFirewallRuleGroup) Read(ctx context.Context, d *utils.Data, meta interface{}) error {
+	var tfFirewallRuleGroup models.CreateRouterFirewallRuleGroup
+	if err := tftags.Get(d, &tfFirewallRuleGroup); err != nil {
+		return err
+	}
+	// Get the router, if the router not exists, return warning
+	router, err := r.routerFirewallRuleGroupClient.GetSpecificRouter(ctx, tfFirewallRuleGroup.RouterID)
+	if err != nil {
+		return err
+	}
+	// if router not found set is_deprecated flag=true
+	if router.ID == 0 {
+		log.Printf("[ERROR] Router with %d id is not found on Firewall Rule Group plan", tfFirewallRuleGroup.RouterID)
+		tfFirewallRuleGroup.IsDeprecated = true
+
+		return tftags.Set(d, tfFirewallRuleGroup)
+	}
+
+	_, err = r.routerFirewallRuleGroupClient.GetSpecificRouterFirewallRuleGroup(ctx, tfFirewallRuleGroup.RouterID,
+		tfFirewallRuleGroup.ID)
+	if err != nil {
+		return err
+	}
+	tfFirewallRuleGroup.IsDeprecated = false
+
+	return tftags.Set(d, tfFirewallRuleGroup)
+}
+
+func (r *routerFirewallRuleGroup) Create(ctx context.Context, d *utils.Data, meta interface{}) error {
+	var tfFirewallRuleGroup models.CreateRouterFirewallRuleGroup
+	err := tftags.Get(d, &tfFirewallRuleGroup)
+	if err != nil {
+		return err
+	}
+	//Setting to Default value "GatewayPolicy"
+	tfFirewallRuleGroup.ExternalType = routerFirewallExternalPolicy
+	firewallGroupRes, err := r.routerFirewallRuleGroupClient.CreateRouterFirewallRuleGroup(ctx, tfFirewallRuleGroup.RouterID,
+		models.CreateRouterFirewallRuleGroupRequest{CreateRouterFirewallRuleGroup: tfFirewallRuleGroup},
+	)
+	if err != nil {
+		return err
+	}
+
+	if !firewallGroupRes.Success {
+		return fmt.Errorf(successErr, "creating firewall rule group for the router")
+	}
+	tfFirewallRuleGroup.ID = firewallGroupRes.ID
+
+	return tftags.Set(d, tfFirewallRuleGroup)
+}
+
+func (r *routerFirewallRuleGroup) Update(ctx context.Context, d *utils.Data, meta interface{}) error {
+	// to be implemented
+	return nil
+}
+
+func (r *routerFirewallRuleGroup) Delete(ctx context.Context, d *utils.Data, meta interface{}) error {
+	var tfFirewallRuleGroup models.CreateRouterFirewallRuleGroup
+	if err := tftags.Get(d, &tfFirewallRuleGroup); err != nil {
+		return err
+	}
+
+	// if parent router got deleted, NAT is already deleted
+	if tfFirewallRuleGroup.IsDeprecated {
+		log.Printf("[WARNING] Firewall rule group already deleted since router is deleted")
+
+		return nil
+	}
+
+	resp, err := r.routerFirewallRuleGroupClient.DeleteRouterFirewallRuleGroup(ctx, tfFirewallRuleGroup.RouterID,
+		tfFirewallRuleGroup.ID)
+	if err != nil {
+		return err
+	}
+	if !resp.Success {
+		return fmt.Errorf("got success = 'false' while deleting firewall rule group rule")
+	}
+
+	return nil
+}

--- a/internal/cmp/router_firewall_rule_group.go
+++ b/internal/cmp/router_firewall_rule_group.go
@@ -57,7 +57,7 @@ func (r *routerFirewallRuleGroup) Create(ctx context.Context, d *utils.Data, met
 	if err != nil {
 		return err
 	}
-	//Setting to Default value "GatewayPolicy"
+	// Setting to Default value "GatewayPolicy"
 	tfFirewallRuleGroup.ExternalType = routerFirewallExternalPolicy
 	firewallGroupRes, err := r.routerFirewallRuleGroupClient.CreateRouterFirewallRuleGroup(ctx, tfFirewallRuleGroup.RouterID,
 		models.CreateRouterFirewallRuleGroupRequest{CreateRouterFirewallRuleGroup: tfFirewallRuleGroup},

--- a/internal/cmp/router_nat.go
+++ b/internal/cmp/router_nat.go
@@ -41,7 +41,7 @@ func (r *routerNat) Read(ctx context.Context, d *utils.Data, meta interface{}) e
 		return tftags.Set(d, tfNat)
 	}
 
-	_, err = r.routerNatClient.GetSpecificRouterNat(ctx, tfNat.ID, tfNat.ID)
+	_, err = r.routerNatClient.GetSpecificRouterNat(ctx, tfNat.RouterID, tfNat.ID)
 	if err != nil {
 		return err
 	}

--- a/internal/resources/constants.go
+++ b/internal/resources/constants.go
@@ -22,11 +22,12 @@ const (
 	DSCloudFolder      = "hpegl_vmaas_cloud_folder"
 	DSRouter           = "hpegl_vmaas_router"
 	// resource key
-	ResInstance      = "hpegl_vmaas_instance"
-	ResInstanceClone = "hpegl_vmaas_instance_clone"
-	ResNetwork       = "hpegl_vmaas_network"
-	ResRouter        = "hpegl_vmaas_router"
-	ResRouterNat     = "hpegl_vmaas_router_nat_rule"
+	ResInstance                = "hpegl_vmaas_instance"
+	ResInstanceClone           = "hpegl_vmaas_instance_clone"
+	ResNetwork                 = "hpegl_vmaas_network"
+	ResRouter                  = "hpegl_vmaas_router"
+	ResRouterNat               = "hpegl_vmaas_router_nat_rule"
+	ResRouterFirewallRuleGroup = "hpegl_vmaas_router_firewall_rule_group"
 
 	// documentation related constants
 	generalNamedesc = "Name of the %s as it appears on GLPC Portal. " +

--- a/internal/resources/resource_router_firewall_rule_groups.go
+++ b/internal/resources/resource_router_firewall_rule_groups.go
@@ -1,0 +1,126 @@
+// (C) Copyright 2021 Hewlett Packard Enterprise Development LP
+
+package resources
+
+import (
+	"context"
+
+	"github.com/HewlettPackard/hpegl-vmaas-terraform-resources/internal/resources/validations"
+	"github.com/HewlettPackard/hpegl-vmaas-terraform-resources/internal/utils"
+	"github.com/HewlettPackard/hpegl-vmaas-terraform-resources/pkg/client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func RouterFirewallRuleGroup() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"router_id": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Parent router ID, router_id can be obtained by using router datasource/resource.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the Firewall rule Group.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Description for the Firewall rule Group.",
+			},
+			"priority": {
+				Type:             schema.TypeInt,
+				Optional:         true,
+				Description:      "Firewall rule group priority",
+				ValidateDiagFunc: validations.IntAtLeast(1),
+			},
+			"group_layer": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateDiagFunc: validations.StringInSlice([]string{
+					"Emergency",
+					"SharedPreRules",
+					"LocalGatewayRules",
+				}, false),
+				Description: "Platform/vendor specific category",
+			},
+			"is_deprecated": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "If parent router not found, then is_deprecated will be true",
+			},
+		},
+		ReadContext:   routerFirewallRuleGroupReadContext,
+		CreateContext: routerFirewallRuleGroupCreateContext,
+		UpdateContext: routerFirewallRuleGroupUpdateContext,
+		DeleteContext: routerFirewallRuleGroupDeleteContext,
+	}
+}
+
+func routerFirewallRuleGroupReadContext(ctx context.Context, rd *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c, err := client.GetClientFromMetaMap(meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	data := utils.NewData(rd)
+	if err := c.CmpClient.RouterFirewallRuleGroup.Read(ctx, data, meta); err != nil {
+		return diag.FromErr(err)
+	}
+	isDeprecated := data.GetBool("is_deprecated")
+	if isDeprecated {
+		return diag.Diagnostics{
+			{
+				Severity: diag.Warning,
+				Summary:  "Parent router is deleted. This resource is deprecated!!!",
+			},
+		}
+	}
+
+	return nil
+}
+
+func routerFirewallRuleGroupCreateContext(ctx context.Context, rd *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c, err := client.GetClientFromMetaMap(meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	data := utils.NewData(rd)
+	if err := c.CmpClient.RouterFirewallRuleGroup.Create(ctx, data, meta); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return routerFirewallRuleGroupReadContext(ctx, rd, meta)
+}
+
+func routerFirewallRuleGroupUpdateContext(ctx context.Context, rd *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c, err := client.GetClientFromMetaMap(meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	data := utils.NewData(rd)
+	if err := c.CmpClient.RouterFirewallRuleGroup.Update(ctx, data, meta); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return routerFirewallRuleGroupReadContext(ctx, rd, meta)
+}
+
+func routerFirewallRuleGroupDeleteContext(ctx context.Context, rd *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c, err := client.GetClientFromMetaMap(meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	data := utils.NewData(rd)
+	if err := c.CmpClient.RouterFirewallRuleGroup.Delete(ctx, data, meta); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}

--- a/pkg/resources/registration.go
+++ b/pkg/resources/registration.go
@@ -43,11 +43,12 @@ func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 
 func (r Registration) SupportedResources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{
-		resources.ResInstance:      resources.Instances(),
-		resources.ResInstanceClone: resources.InstancesClone(),
-		resources.ResNetwork:       resources.Network(),
-		resources.ResRouter:        resources.Router(),
-		resources.ResRouterNat:     resources.RouterNatRule(),
+		resources.ResInstance:                resources.Instances(),
+		resources.ResInstanceClone:           resources.InstancesClone(),
+		resources.ResNetwork:                 resources.Network(),
+		resources.ResRouter:                  resources.Router(),
+		resources.ResRouterNat:               resources.RouterNatRule(),
+		resources.ResRouterFirewallRuleGroup: resources.RouterFirewallRuleGroup(),
 	}
 }
 


### PR DESCRIPTION
```


manjuna@ubuntu:~/hpe-hcss/terraform$ TF_REATTACH_PROVIDERS='{"terraform.example.com/vmaas/hpegl":{"Protocol":"grpc","ProtocolVersion":5,"Pid":177855,"Test":true,"Addr":{"Network":"unix","String":"/tmp/plugin1746432112"}}}' terraform plan

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # hpegl_vmaas_router_firewall_rule_group.tf_router_firewall_rule_group will be created
  + resource "hpegl_vmaas_router_firewall_rule_group" "tf_router_firewall_rule_group" {
      + description   = "Router Firewall rule group created via terraform"
      + group_layer   = "LocalGatewayRules"
      + id            = (known after apply)
      + is_deprecated = (known after apply)
      + name          = "tf_router_firewall_group"
      + priority      = 120
      + router_id     = 59
    }

Plan: 1 to add, 0 to change, 0 to destroy.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
manjuna@ubuntu:~/hpe-hcss/terraform$ TF_REATTACH_PROVIDERS='{"terraform.example.com/vmaas/hpegl":{"Protocol":"grpc","ProtocolVersion":5,"Pid":177855,"Test":true,"Addr":{"Network":"unix","String":"/tmp/plugin1746432112"}}}' terraform apply

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # hpegl_vmaas_router_firewall_rule_group.tf_router_firewall_rule_group will be created
  + resource "hpegl_vmaas_router_firewall_rule_group" "tf_router_firewall_rule_group" {
      + description   = "Router Firewall rule group created via terraform"
      + group_layer   = "LocalGatewayRules"
      + id            = (known after apply)
      + is_deprecated = (known after apply)
      + name          = "tf_router_firewall_group"
      + priority      = 120
      + router_id     = 59
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

hpegl_vmaas_router_firewall_rule_group.tf_router_firewall_rule_group: Creating...
hpegl_vmaas_router_firewall_rule_group.tf_router_firewall_rule_group: Creation complete after 3s [id=37]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
manjuna@ubuntu:~/hpe-hcss/terraform$ TF_REATTACH_PROVIDERS='{"terraform.example.com/vmaas/hpegl":{"Protocol":"grpc","ProtocolVersion":5,"Pid":177855,"Test":true,"Addr":{"Network":"unix","String":"/tmp/plugin1746432112"}}}' terraform destroy
hpegl_vmaas_router_firewall_rule_group.tf_router_firewall_rule_group: Refreshing state... [id=37]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # hpegl_vmaas_router_firewall_rule_group.tf_router_firewall_rule_group will be destroyed
  - resource "hpegl_vmaas_router_firewall_rule_group" "tf_router_firewall_rule_group" {
      - description = "Router Firewall rule group created via terraform" -> null
      - group_layer = "LocalGatewayRules" -> null
      - id          = "37" -> null
      - name        = "tf_router_firewall_group" -> null
      - priority    = 120 -> null
      - router_id   = 59 -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

hpegl_vmaas_router_firewall_rule_group.tf_router_firewall_rule_group: Destroying... [id=37]
hpegl_vmaas_router_firewall_rule_group.tf_router_firewall_rule_group: Destruction complete after 1s

Destroy complete! Resources: 1 destroyed.
```