### PR TITLE
[DE9021] Handle the case of snapshot deletion

### DIFF
--- a/internal/cmp/instance_helper.go
+++ b/internal/cmp/instance_helper.go
@@ -151,6 +151,9 @@ func updateInstance(ctx context.Context, sharedClient instanceSharedClient, d *u
 
 	if d.HasChanged("snapshot") {
 		snapshot := d.GetListMap("snapshot")
+		if len(snapshot) <= 0 {
+			return fmt.Errorf("Deleting snapshot is not supported currently.")
+		}
 		err := createInstanceSnapshot(ctx, sharedClient, getInstance.Instance.ID, models.SnapshotBody{
 			Snapshot: &models.SnapshotBodySnapshot{
 				Name:        snapshot[0]["name"].(string),

--- a/internal/cmp/instance_helper.go
+++ b/internal/cmp/instance_helper.go
@@ -151,9 +151,6 @@ func updateInstance(ctx context.Context, sharedClient instanceSharedClient, d *u
 
 	if d.HasChanged("snapshot") {
 		snapshot := d.GetListMap("snapshot")
-		if len(snapshot) <= 0 {
-			return fmt.Errorf("Deleting snapshot is not supported currently.")
-		}
 		err := createInstanceSnapshot(ctx, sharedClient, getInstance.Instance.ID, models.SnapshotBody{
 			Snapshot: &models.SnapshotBodySnapshot{
 				Name:        snapshot[0]["name"].(string),

--- a/internal/resources/diffValidation/resource_instances.go
+++ b/internal/resources/diffValidation/resource_instances.go
@@ -55,6 +55,10 @@ func (i *Instance) DiffValidate() error {
 		return err
 	}
 
+	if err := i.instanceValidateSnapshotDeletion(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -203,4 +207,18 @@ func (i *Instance) instanceValidatePowerTransition() error {
 	}
 
 	return fmt.Errorf("power operation not allowed from %s state to %s state", oldPowerStr, newPowerStr)
+}
+
+func (i *Instance) instanceValidateSnapshotDeletion() error {
+	if !i.diff.HasChange("snapshot") {
+		return nil
+	}
+	// if there is a change in snapshot, then get the new value
+	_, newSnapshotValue := i.diff.GetChange("snapshot")
+	newMap := utils.GetlistMap(newSnapshotValue)
+	// if an attempt to delete the snapshot, then return error
+	if len(newMap) <= 0 {
+		return fmt.Errorf("Deleting snapshot is not supported currently.")
+	}
+	return nil
 }


### PR DESCRIPTION
## Description
As the deletion of snapshot is not supported currently, this code handles runtime exceptions which could arise when user tries to delete the snapshot. It notifies the user at the terraform plan time itself.
<img width="457" alt="image" src="https://user-images.githubusercontent.com/84033942/149374416-1c86640d-5165-4e61-86d2-118a63846a24.png">

