### PR TITLE
[DE8379][DE8373] Plan and Network Reconfigure

### DIFF
--- a/internal/cmp/instance_helper.go
+++ b/internal/cmp/instance_helper.go
@@ -586,12 +586,20 @@ func instanceUpdateNetworkVolume(
 		if err := d.Error(); err != nil {
 			return err
 		}
+	} else if d.HasChanged("plan_id") {
+		resizeReq = models.ResizeInstanceBody{
+			Instance: &models.ResizeInstanceBodyInstance{
+				Plan: &models.ResizeInstanceBodyInstancePlan{
+					ID: d.GetInt("plan_id"),
+				},
+			},
+		}
 	}
 	if d.HasChanged("network") {
 		schemaNetwork := d.GetListMap("network")
 		resizeReq.NetworkInterfaces = instanceGetResizeNetwork(schemaNetwork)
 	}
-	if d.HasChanged("volume") || d.HasChanged("network") {
+	if d.HasChanged("volume") || d.HasChanged("network") || d.HasChanged("plan_id") {
 		updateResp, err := sharedClient.iClient.ResizeAnInstance(ctx, instanceID, &resizeReq)
 		if err != nil {
 			return err

--- a/internal/resources/diffValidation/resource_instances.go
+++ b/internal/resources/diffValidation/resource_instances.go
@@ -4,14 +4,11 @@ package diffvalidation
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 
 	"github.com/HewlettPackard/hpegl-vmaas-terraform-resources/internal/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
-
-var errPrimaryNetworkUpdation = fmt.Errorf("primary network updation/deletion is not supported")
 
 type Instance struct {
 	diff *schema.ResourceDiff
@@ -24,7 +21,7 @@ func NewInstanceValidate(diff *schema.ResourceDiff) *Instance {
 }
 
 func (i *Instance) DiffValidate() error {
-	notAllowed := []string{"plan_id", "scale"}
+	notAllowed := []string{"scale"}
 
 	for _, param := range notAllowed {
 		if i.diff.HasChange(param) {
@@ -51,40 +48,8 @@ func (i *Instance) DiffValidate() error {
 		return err
 	}
 
-	if err := i.validateIsPrimaryNetworkChanged(); err != nil {
-		return err
-	}
-
 	if err := i.instanceValidateSnapshotDeletion(); err != nil {
 		return err
-	}
-
-	return nil
-}
-
-func (i *Instance) validateIsPrimaryNetworkChanged() error {
-	if i.diff.HasChange("network") {
-		o, n := i.diff.GetChange("network")
-		oldMap := utils.GetlistMap(o)
-		newMap := utils.GetlistMap(n)
-
-		// skip upon create operation
-		if len(oldMap) == 0 {
-			return nil
-		}
-		// check whether primary network has been changed?
-		for i := range oldMap {
-			if oldMap[i]["is_primary"].(bool) {
-				if len(newMap) < i {
-					return errPrimaryNetworkUpdation
-				}
-				if !reflect.DeepEqual(newMap[i], oldMap[i]) {
-					return errPrimaryNetworkUpdation
-				}
-
-				break
-			}
-		}
 	}
 
 	return nil
@@ -218,7 +183,7 @@ func (i *Instance) instanceValidateSnapshotDeletion() error {
 	newMap := utils.GetlistMap(newSnapshotValue)
 	// if an attempt to delete the snapshot, then return error
 	if len(newMap) <= 0 {
-		return fmt.Errorf("Deleting snapshot is not supported currently.")
+		return fmt.Errorf("deleting snapshot is not supported currently")
 	}
 	return nil
 }

--- a/internal/resources/resource_instances_helper.go
+++ b/internal/resources/resource_instances_helper.go
@@ -72,7 +72,6 @@ func getInstanceDefaultSchema(isClone bool) *schema.Resource {
 				Type:        schema.TypeInt,
 				Optional:    isClone,
 				Required:    !isClone,
-				ForceNew:    true,
 				Description: f(generalDDesc, "plan"),
 			},
 			"instance_type_code": {


### PR DESCRIPTION
## Description
- Requirement: Change of plan should not recreate the existing instance.
   Changes Made: 
   1) Remove 'force new' option 
   2) Earlier, change in volume also included the change in plan, so adding a separate option to change plan ( Note: If there is a change in volume then there is no need to separately run the change in plan code)
- Requirement: Change of network should not recreate the existing instance. Allow the change in primary network. 
   Changes Made:
   1) Removed the diff Validation check on the primary network, which was put to check that the primary network is neither updated or deleted. (Note: The constraint that network block should be at least 1 ensures that the user does not remove all the network)