### PR TITLE
 Fix Lint issues

### DIFF
--- a/internal/acceptance_test/helper.go
+++ b/internal/acceptance_test/helper.go
@@ -33,7 +33,7 @@ func getAPIClient() (*api_client.APIClient, api_client.Configuration) {
 	}
 
 	apiClient := api_client.NewAPIClient(&cfg)
-	apiClient.SetMeta(nil, func(ctx *context.Context, meta interface{}) {
+	meta_err := apiClient.SetMeta(nil, func(ctx *context.Context, meta interface{}) {
 		d := &utils.ResourceData{
 			Data: map[string]interface{}{
 				"iam_service_url":           os.Getenv("HPEGL_IAM_SERVICE_URL"),
@@ -63,6 +63,10 @@ func getAPIClient() (*api_client.APIClient, api_client.Configuration) {
 			*ctx = context.WithValue(*ctx, api_client.ContextAccessToken, token)
 		}
 	})
+
+	if meta_err != nil {
+		log.Printf("[WARN] Error returned: %s", meta_err)
+	}
 
 	return apiClient, cfg
 }

--- a/internal/acceptance_test/helper.go
+++ b/internal/acceptance_test/helper.go
@@ -33,7 +33,7 @@ func getAPIClient() (*api_client.APIClient, api_client.Configuration) {
 	}
 
 	apiClient := api_client.NewAPIClient(&cfg)
-	meta_err := apiClient.SetMeta(nil, func(ctx *context.Context, meta interface{}) {
+	err := apiClient.SetMeta(nil, func(ctx *context.Context, meta interface{}) {
 		d := &utils.ResourceData{
 			Data: map[string]interface{}{
 				"iam_service_url":           os.Getenv("HPEGL_IAM_SERVICE_URL"),
@@ -64,8 +64,8 @@ func getAPIClient() (*api_client.APIClient, api_client.Configuration) {
 		}
 	})
 
-	if meta_err != nil {
-		log.Printf("[WARN] Error: %s", meta_err)
+	if err != nil {
+		log.Printf("[WARN] Error: %s", err)
 	}
 
 	return apiClient, cfg

--- a/internal/acceptance_test/helper.go
+++ b/internal/acceptance_test/helper.go
@@ -65,7 +65,7 @@ func getAPIClient() (*api_client.APIClient, api_client.Configuration) {
 	})
 
 	if meta_err != nil {
-		log.Printf("[WARN] Error returned: %s", meta_err)
+		log.Printf("[WARN] Error: %s", meta_err)
 	}
 
 	return apiClient, cfg

--- a/internal/cmp/cloud_folder.go
+++ b/internal/cmp/cloud_folder.go
@@ -38,7 +38,10 @@ func (f *cloudFolder) Read(ctx context.Context, d *utils.Data, meta interface{})
 
 	for _, cf := range folders.Folders {
 		if cf.Name == name {
-			d.Set("code", cf.ExternalID)
+			err = d.Set("code", cf.ExternalID)
+			if err != nil {
+				return err
+			}
 			d.SetID(cf.ID)
 
 			return nil

--- a/internal/cmp/domain.go
+++ b/internal/cmp/domain.go
@@ -39,7 +39,10 @@ func (n *domain) Read(ctx context.Context, d *utils.Data, meta interface{}) erro
 		return errors.New("error coudn't find exact domain, please check the name")
 	}
 
-	tftags.Set(d, domains.NetworkDomains[0])
+	err = tftags.Set(d, domains.NetworkDomains[0])
+	if err != nil {
+		return err
+	}
 
 	// post check
 	return d.Error()

--- a/internal/cmp/instance_helper.go
+++ b/internal/cmp/instance_helper.go
@@ -70,7 +70,10 @@ func readInstance(ctx context.Context, sharedClient instanceSharedClient, d *uti
 	})
 
 	if isClone {
-		d.Set("layout_id", instance.Instance.Layout.ID)
+		err = d.Set("layout_id", instance.Instance.Layout.ID)
+		if err != nil {
+			return err
+		}
 	}
 
 	tfInstance.Network, err = instanceGetNetworkModel(tfInstance.Network, serverRetry)
@@ -83,7 +86,10 @@ func readInstance(ctx context.Context, sharedClient instanceSharedClient, d *uti
 	tfInstance.History = instanceGetHistoryModel(historyRetry)
 	tfInstance.Containers = instance.Instance.ContainerDetails
 
-	tftags.Set(d, tfInstance)
+	err = tftags.Set(d, tfInstance)
+	if err != nil {
+		return err
+	}
 
 	d.SetID(instance.Instance.ID)
 
@@ -542,7 +548,10 @@ func instanceSetServerID(ctx context.Context, d *utils.Data, sharedClient instan
 	if len(servers.Server) != 1 {
 		return fmt.Errorf(errExactMatch, "server")
 	}
-	d.Set("server_id", servers.Server[0].ID)
+	err = d.Set("server_id", servers.Server[0].ID)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/internal/cmp/network_interface.go
+++ b/internal/cmp/network_interface.go
@@ -52,7 +52,10 @@ func (c *networkInterface) Read(ctx context.Context, d *utils.Data, meta interfa
 
 	for _, n := range networkInterface.Data.NetworkTypes {
 		if n.Name == name {
-			d.Set("code", n.Code)
+			err = d.Set("code", n.Code)
+			if err != nil {
+				return err
+			}
 			d.SetID(n.ID)
 
 			return d.Error()

--- a/internal/cmp/network_proxy.go
+++ b/internal/cmp/network_proxy.go
@@ -23,8 +23,10 @@ func newNetworkProxy(nClient *client.NetworksAPIService) *networkProxy {
 func (n *networkProxy) Read(ctx context.Context, d *utils.Data, meta interface{}) error {
 	setMeta(meta, n.nClient.Client)
 	tfProxy := models.GetNetworkProxy{}
-	tftags.Get(d, &tfProxy)
-
+	err := tftags.Get(d, &tfProxy)
+	if err != nil {
+		return err
+	}
 	proxyResp, err := n.nClient.GetNetworkProxy(ctx, map[string]string{
 		nameKey: tfProxy.Name,
 	})

--- a/internal/cmp/router.go
+++ b/internal/cmp/router.go
@@ -41,8 +41,9 @@ func (r *router) Create(ctx context.Context, d *utils.Data, meta interface{}) er
 		return err
 	}
 	// align createReq and fill json related fields
-	r.routerAlignRouterRequest(ctx, meta, &createReq)
-
+	if err := r.routerAlignRouterRequest(ctx, meta, &createReq); err != nil {
+		return err
+	}
 	routerResp, err := r.rClient.CreateRouter(ctx, createReq)
 	if err != nil {
 		return err
@@ -60,9 +61,12 @@ func (r *router) Create(ctx context.Context, d *utils.Data, meta interface{}) er
 			return response.(models.GetSpecificRouterResp).NetworkRouter.Status == "ok", nil
 		},
 	}
-	retry.Retry(ctx, meta, func(ctx context.Context) (interface{}, error) {
+	_, err = retry.Retry(ctx, meta, func(ctx context.Context) (interface{}, error) {
 		return r.rClient.GetSpecificRouter(ctx, routerResp.ID)
 	})
+	if err != nil {
+		return err
+	}
 
 	return tftags.Set(d, createReq.NetworkRouter)
 }
@@ -73,7 +77,9 @@ func (r *router) Update(ctx context.Context, d *utils.Data, meta interface{}) er
 		return err
 	}
 	// align createReq and fill json related fields
-	r.routerAlignRouterRequest(ctx, meta, &createReq)
+	if err := r.routerAlignRouterRequest(ctx, meta, &createReq); err != nil {
+		return err
+	}
 
 	// HaMode cannot be updated, setting it to empty so that it is ignored in the API Payload.
 	createReq.NetworkRouter.Config.HaMode = ""

--- a/pkg/atf/helper.go
+++ b/pkg/atf/helper.go
@@ -4,6 +4,7 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
+	"log"
 	"math/rand"
 	"runtime"
 	"strconv"
@@ -89,7 +90,7 @@ func newRand() *rand.Rand {
 	m := md5.New()
 	_, err := m.Write([]byte(s))
 	if err != nil {
-		panic(err)
+		log.Printf("[WARN]: Error while writing to Hash object %s", err)
 	}
 	sourceStr := m.Sum(nil)
 	var sourceInt int64

--- a/pkg/atf/helper.go
+++ b/pkg/atf/helper.go
@@ -87,7 +87,10 @@ func toInt(str string) int {
 func newRand() *rand.Rand {
 	s := myCaller()
 	m := md5.New()
-	m.Write([]byte(s))
+	_, err := m.Write([]byte(s))
+	if err != nil {
+		panic(err)
+	}
 	sourceStr := m.Sum(nil)
 	var sourceInt int64
 	for _, i := range sourceStr {

--- a/pkg/utils/meta.go
+++ b/pkg/utils/meta.go
@@ -11,7 +11,7 @@ import (
 )
 
 func SetMeta(apiClient *client.APIClient, r *schema.ResourceData) {
-	apiClient.SetMeta(nil, func(ctx *context.Context, meta interface{}) {
+	meta_err := apiClient.SetMeta(nil, func(ctx *context.Context, meta interface{}) {
 		// Initialise token handler
 		h, err := serviceclient.NewHandler(r)
 		if err != nil {
@@ -27,4 +27,8 @@ func SetMeta(apiClient *client.APIClient, r *schema.ResourceData) {
 			*ctx = context.WithValue(*ctx, client.ContextAccessToken, token)
 		}
 	})
+
+	if meta_err != nil {
+		log.Printf("[ERR] Error returned: %s", meta_err)
+	}
 }

--- a/pkg/utils/meta.go
+++ b/pkg/utils/meta.go
@@ -11,7 +11,7 @@ import (
 )
 
 func SetMeta(apiClient *client.APIClient, r *schema.ResourceData) {
-	meta_err := apiClient.SetMeta(nil, func(ctx *context.Context, meta interface{}) {
+	err := apiClient.SetMeta(nil, func(ctx *context.Context, meta interface{}) {
 		// Initialise token handler
 		h, err := serviceclient.NewHandler(r)
 		if err != nil {
@@ -28,7 +28,7 @@ func SetMeta(apiClient *client.APIClient, r *schema.ResourceData) {
 		}
 	})
 
-	if meta_err != nil {
-		log.Printf("[WARN] Error: %s", meta_err)
+	if err != nil {
+		log.Printf("[WARN] Error: %s", err)
 	}
 }

--- a/pkg/utils/meta.go
+++ b/pkg/utils/meta.go
@@ -29,6 +29,6 @@ func SetMeta(apiClient *client.APIClient, r *schema.ResourceData) {
 	})
 
 	if meta_err != nil {
-		log.Printf("[ERR] Error returned: %s", meta_err)
+		log.Printf("[WARN] Error: %s", meta_err)
 	}
 }


### PR DESCRIPTION
Following Lint issues are fixed:


```
Makefile:69: warning: ignoring old recipe for target 'tools'
==> Checking source code against linters...
golangci-lint run ./...
internal/cmp/cloud_folder.go:41:9: Error return value of `d.Set` is not checked (errcheck)
                        d.Set("code", cf.ExternalID)
                             ^
internal/cmp/domain.go:42:12: Error return value of `tftags.Set` is not checked (errcheck)
        tftags.Set(d, domains.NetworkDomains[0])
                  ^
internal/cmp/instance_helper.go:73:8: Error return value of `d.Set` is not checked (errcheck)
                d.Set("layout_id", instance.Instance.Layout.ID)
                     ^
internal/cmp/instance_helper.go:86:12: Error return value of `tftags.Set` is not checked (errcheck)
        tftags.Set(d, tfInstance)
                  ^
internal/cmp/instance_helper.go:545:7: Error return value of `d.Set` is not checked (errcheck)
        d.Set("server_id", servers.Server[0].ID)
             ^
internal/cmp/network_proxy.go:26:12: Error return value of `tftags.Get` is not checked (errcheck)
        tftags.Get(d, &tfProxy)
                  ^
internal/cmp/router.go:44:28: Error return value of `r.routerAlignRouterRequest` is not checked (errcheck)
        r.routerAlignRouterRequest(ctx, meta, &createReq)
                                  ^
internal/cmp/router.go:63:13: Error return value of `retry.Retry` is not checked (errcheck)
        retry.Retry(ctx, meta, func(ctx context.Context) (interface{}, error) {
                   ^
internal/cmp/router.go:76:28: Error return value of `r.routerAlignRouterRequest` is not checked (errcheck)
        r.routerAlignRouterRequest(ctx, meta, &createReq)
                                  ^
pkg/utils/meta.go:14:19: Error return value of `apiClient.SetMeta` is not checked (errcheck)
        apiClient.SetMeta(nil, func(ctx *context.Context, meta interface{}) {
                         ^
pkg/atf/helper.go:90:9: Error return value of `m.Write` is not checked (errcheck)
        m.Write([]byte(s))
               ^
internal/acceptance_test/helper.go:36:19: Error return value of `apiClient.SetMeta` is not checked (errcheck)
        apiClient.SetMeta(nil, func(ctx *context.Context, meta interface{}) {
                         ^
make: *** [Makefile:73: lint] Error 1

rand.New(rand.NewSource(999999))
```