### PR TITLE
Tier0 Router fixes

### DIFF
--- a/internal/cmp/router.go
+++ b/internal/cmp/router.go
@@ -4,9 +4,7 @@ package cmp
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"log"
 
 	"github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/client"
 	"github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/models"
@@ -46,8 +44,6 @@ func (r *router) Create(ctx context.Context, d *utils.Data, meta interface{}) er
 	if err := r.routerAlignRouterRequest(ctx, meta, &createReq); err != nil {
 		return err
 	}
-	val, _ := json.Marshal(&createReq)
-	log.Printf("Router value: %s", string(val))
 	routerResp, err := r.rClient.CreateRouter(ctx, createReq)
 	if err != nil {
 		return err

--- a/internal/cmp/router.go
+++ b/internal/cmp/router.go
@@ -4,7 +4,9 @@ package cmp
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"log"
 
 	"github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/client"
 	"github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/models"
@@ -44,6 +46,8 @@ func (r *router) Create(ctx context.Context, d *utils.Data, meta interface{}) er
 	if err := r.routerAlignRouterRequest(ctx, meta, &createReq); err != nil {
 		return err
 	}
+	val, _ := json.Marshal(&createReq)
+	log.Printf("Router value: %s", string(val))
 	routerResp, err := r.rClient.CreateRouter(ctx, createReq)
 	if err != nil {
 		return err
@@ -142,7 +146,7 @@ func (r *router) routerAlignRouterRequest(ctx context.Context, meta interface{},
 		routerReq.NetworkRouter.Config.HaMode = routerReq.NetworkRouter.TfTier0Config.TfHaMode
 		routerReq.NetworkRouter.Config.FailOver = routerReq.NetworkRouter.TfTier0Config.TfFailOver
 		routerReq.NetworkRouter.Config.EdgeCluster = routerReq.NetworkRouter.TfTier0Config.TfEdgeCluster
-		routerReq.NetworkRouter.EnableBGP = routerReq.NetworkRouter.TfTier0Config.Bgp.TfEnableBgp
+		routerReq.NetworkRouter.EnableBGP = routerReq.NetworkRouter.TfTier0Config.TfBGP.TfEnableBgp
 		queryParam[nameKey] = tier0GatewayType
 	} else {
 		routerReq.NetworkRouter.Config.CreateRouterTier0Config.RouteRedistributionTier1.RouteAdvertisement =

--- a/internal/resources/diffValidation/constants.go
+++ b/internal/resources/diffValidation/constants.go
@@ -1,0 +1,9 @@
+//  (C) Copyright 2021 Hewlett Packard Enterprise Development LP
+
+package diffvalidation
+
+const (
+	// Router Constants
+	DefaultRestartTimer = 180
+	DefaultStaleTimer   = 600
+)

--- a/internal/resources/diffValidation/resourse_router.go
+++ b/internal/resources/diffValidation/resourse_router.go
@@ -52,17 +52,16 @@ func (r *Router) validateTier0Config() error {
 	}
 
 	//BGP graceful restart timers cannot be updated when BGP config is enabled
-	bgpEnabledPath := "tier0_config.0.bgp.0.enable_bgp"
-	if r.diff.HasChange(bgpEnabledPath) || (r.diff.HasChange("tier0_config.0.bgp.0.restart_time") || r.diff.HasChange("tier0_config.0.bgp.0.stale_route_time")) {
-		action := r.diff.Get(bgpEnabledPath)
+	if r.diff.HasChange(utils.BgpEnabledPath) || (r.diff.HasChange(utils.BgpRestartTimerPath) || r.diff.HasChange(utils.BgpStaleTimerPath)) {
+		action := r.diff.Get(utils.BgpEnabledPath)
 		if action.(bool) {
-			oldRestartTimer, newRestartTimer := r.diff.GetChange("tier0_config.0.bgp.0.restart_time")
-			oldStaleTimer, newStaleTimer := r.diff.GetChange("tier0_config.0.bgp.0.stale_route_time")
+			currRestartTimer, newRestartTimer := r.diff.GetChange(utils.BgpRestartTimerPath)
+			currStaleTimer, newStaleTimer := r.diff.GetChange(utils.BgpStaleTimerPath)
 			// During the creation of the Router
-			if (r.diff.HasChange("tier0_config.0.bgp.0.restart_time") && utils.IsEmpty(oldRestartTimer) && newRestartTimer.(int) != utils.DefaultRestartTimer) || (r.diff.HasChange("tier0_config.0.bgp.0.stale_route_time") && utils.IsEmpty(oldStaleTimer) && newStaleTimer.(int) != utils.DefaultStaleTimer) {
+			if (r.diff.HasChange(utils.BgpRestartTimerPath) && utils.IsEmpty(currRestartTimer) && newRestartTimer.(int) != utils.DefaultRestartTimer) || (r.diff.HasChange(utils.BgpStaleTimerPath) && utils.IsEmpty(currStaleTimer) && newStaleTimer.(int) != utils.DefaultStaleTimer) {
 				return fmt.Errorf("BGP graceful restart timers cannot be updated when BGP config is enabled")
 				// While updating the Router
-			} else if (r.diff.HasChange("tier0_config.0.bgp.0.restart_time") && !utils.IsEmpty(oldRestartTimer)) || (r.diff.HasChange("tier0_config.0.bgp.0.stale_route_time") && !utils.IsEmpty(oldStaleTimer)) {
+			} else if (r.diff.HasChange(utils.BgpRestartTimerPath) && !utils.IsEmpty(currRestartTimer)) || (r.diff.HasChange(utils.BgpStaleTimerPath) && !utils.IsEmpty(currStaleTimer)) {
 				return fmt.Errorf("BGP graceful restart timers cannot be updated when BGP config is enabled")
 				// While updating the Router
 			}

--- a/internal/utils/constants.go
+++ b/internal/utils/constants.go
@@ -35,6 +35,9 @@ const (
 	Deleted  = "deleted"
 	Failed   = "failed"
 	// Router Constants
+	BgpEnabledPath      = "tier0_config.0.bgp.0.enable_bgp"
+	BgpRestartTimerPath = "tier0_config.0.bgp.0.restart_time"
+	BgpStaleTimerPath   = "tier0_config.0.bgp.0.stale_route_time"
 	DefaultRestartTimer = 180
 	DefaultStaleTimer   = 600
 )

--- a/internal/utils/constants.go
+++ b/internal/utils/constants.go
@@ -34,10 +34,4 @@ const (
 	Deleting = "deleting"
 	Deleted  = "deleted"
 	Failed   = "failed"
-	// Router Constants
-	BgpEnabledPath      = "tier0_config.0.bgp.0.enable_bgp"
-	BgpRestartTimerPath = "tier0_config.0.bgp.0.restart_time"
-	BgpStaleTimerPath   = "tier0_config.0.bgp.0.stale_route_time"
-	DefaultRestartTimer = 180
-	DefaultStaleTimer   = 600
 )

--- a/internal/utils/constants.go
+++ b/internal/utils/constants.go
@@ -34,4 +34,7 @@ const (
 	Deleting = "deleting"
 	Deleted  = "deleted"
 	Failed   = "failed"
+	// Router Constants
+	DefaultRestartTimer = 180
+	DefaultStaleTimer   = 600
 )


### PR DESCRIPTION
as per NSX-T, we will not be able to update to BGP timers when BGP is enabled. BGP timers can only be updated by turning off global BGP and then update the BGP timers to different values and then enable bgp back.

this code change takes care of two things
1. When the user is creating a Tier0 router, user can enabled bgp and set the restart timers to default values. This is supported operation, if the user tries to use non default values during the creation, operation is not allowed when bgp is enabled.
2. When the user tries to update the existing data with the new restart timers values, operation is not supported. He needs to turn off the bgp and update the timers, then enable bgp again.