### PR TITLE
[DE8379] Allow primary network updation

### DIFF
--- a/internal/resources/diffValidation/resource_instances.go
+++ b/internal/resources/diffValidation/resource_instances.go
@@ -4,14 +4,11 @@ package diffvalidation
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 
 	"github.com/HewlettPackard/hpegl-vmaas-terraform-resources/internal/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
-
-var errPrimaryNetworkUpdation = fmt.Errorf("primary network updation/deletion is not supported")
 
 type Instance struct {
 	diff *schema.ResourceDiff
@@ -51,40 +48,8 @@ func (i *Instance) DiffValidate() error {
 		return err
 	}
 
-	if err := i.validateIsPrimaryNetworkChanged(); err != nil {
-		return err
-	}
-
 	if err := i.instanceValidateSnapshotDeletion(); err != nil {
 		return err
-	}
-
-	return nil
-}
-
-func (i *Instance) validateIsPrimaryNetworkChanged() error {
-	if i.diff.HasChange("network") {
-		o, n := i.diff.GetChange("network")
-		oldMap := utils.GetlistMap(o)
-		newMap := utils.GetlistMap(n)
-
-		// skip upon create operation
-		if len(oldMap) == 0 {
-			return nil
-		}
-		// check whether primary network has been changed?
-		for i := range oldMap {
-			if oldMap[i]["is_primary"].(bool) {
-				if len(newMap) < i {
-					return errPrimaryNetworkUpdation
-				}
-				if !reflect.DeepEqual(newMap[i], oldMap[i]) {
-					return errPrimaryNetworkUpdation
-				}
-
-				break
-			}
-		}
 	}
 
 	return nil
@@ -218,7 +183,7 @@ func (i *Instance) instanceValidateSnapshotDeletion() error {
 	newMap := utils.GetlistMap(newSnapshotValue)
 	// if an attempt to delete the snapshot, then return error
 	if len(newMap) <= 0 {
-		return fmt.Errorf("Deleting snapshot is not supported currently.")
+		return fmt.Errorf("deleting snapshot is not supported currently")
 	}
 	return nil
 }

--- a/internal/resources/resource_instances_helper.go
+++ b/internal/resources/resource_instances_helper.go
@@ -103,7 +103,7 @@ func getInstanceDefaultSchema(isClone bool) *schema.Resource {
 						"is_primary": {
 							Type:        schema.TypeBool,
 							Computed:    true,
-							Description: `Flag to identify given network is primary or not. Primary network cannot be updated or deleted.`,
+							Description: `Flag to identify given network is primary or not. Primary network cannot be deleted.`,
 						},
 						"internal_id": {
 							Type:        schema.TypeInt,


### PR DESCRIPTION
## Description
* Requirement: 
1) Change in network should not recreate the existing instance. 
2) Also allow the change in primary network.
* Changes Made:
1) 1st requirement was already handled in some other PR ( by removing the force_new=true). 
2) 2nd requirement is handled by removing the diff Validation check on the primary network, which was put to check that the primary network is neither updated or deleted. (Note: The constraint that network block should be at least 1 ensures that the user does not remove all the networks. This ensures that 1 network exists and it will be considered as primary network).