### PR TITLE
Lint issues 

### DIFF
--- a/golangci-lint-config.yaml
+++ b/golangci-lint-config.yaml
@@ -49,6 +49,7 @@ linters:
     - nilerr
     - thelper
     # Temporarily disabling these
+    - errorlint
     - predeclared
     - paralleltest
     - gocritic

--- a/golangci-lint-config.yaml
+++ b/golangci-lint-config.yaml
@@ -8,8 +8,8 @@ run:
   build-tags: acceptance
 
 linters-settings:
-  # dupl:
-  #   threshold: 110
+  dupl:
+    threshold: 110
   lll:
     line-length: 128
   goimports:
@@ -41,13 +41,21 @@ linters:
     - gochecknoinits
     - gochecknoglobals
     - errcheck
-    # - exhaustivestruct
     # - forbidigo
     - testpackage
     - nolintlint
     - scopelint
-    # Temporarily disabling paralleltest
-    # - paralleltest
+    - wrapcheck
+    - nilerr
+    - thelper
+    # Temporarily disabling these
+    - predeclared
+    - paralleltest
+    - gocritic
+    - forcetypeassert
+    - ifshort
+    - exhaustivestruct
+    - cyclop
     #Temporarily disabling wrapcheck
     # - wrapcheck
     # Disable the 'cyclop' cyclometric complexity linter. 'gocyclo' already

--- a/golangci-lint-config.yaml
+++ b/golangci-lint-config.yaml
@@ -57,6 +57,9 @@ linters:
     - ifshort
     - exhaustivestruct
     - cyclop
+    - varnamelen
+    - maintidx
+    - ireturn
     #Temporarily disabling wrapcheck
     # - wrapcheck
     # Disable the 'cyclop' cyclometric complexity linter. 'gocyclo' already

--- a/internal/acceptance_test/data_source_edge_cluster_test.go
+++ b/internal/acceptance_test/data_source_edge_cluster_test.go
@@ -37,6 +37,7 @@ func TestAccDataSourceNetworkEdgeCluster(t *testing.T) {
 					break
 				}
 			}
+
 			return iClient.GetEdgeCluster(getAccContext(), serverID, name)
 		},
 	}

--- a/internal/acceptance_test/helper.go
+++ b/internal/acceptance_test/helper.go
@@ -63,7 +63,6 @@ func getAPIClient() (*api_client.APIClient, api_client.Configuration) {
 			*ctx = context.WithValue(*ctx, api_client.ContextAccessToken, token)
 		}
 	})
-
 	if err != nil {
 		log.Printf("[WARN] Error: %s", err)
 	}

--- a/internal/cmp/instance_clone.go
+++ b/internal/cmp/instance_clone.go
@@ -226,7 +226,10 @@ func cloneInstance(
 		},
 	}
 	_, err := cloneRetry.Retry(ctx, meta, func(ctx context.Context) (interface{}, error) {
-		val, _ := json.Marshal(&req)
+		val, err := json.Marshal(&req)
+		if err != nil {
+			return nil, err
+		}
 		log.Printf("value: %s", string(val))
 
 		return i.iClient.CloneAnInstance(ctx, sourceID, req)

--- a/internal/cmp/resource_network.go
+++ b/internal/cmp/resource_network.go
@@ -132,7 +132,7 @@ func (r *resNetwork) Delete(ctx context.Context, d *utils.Data, meta interface{}
 	networkID := d.GetID()
 	resp, err := r.nClient.DeleteNetwork(ctx, networkID)
 	if !resp.Success {
-		return fmt.Errorf("got success as false on delete network, error: %v", err)
+		return fmt.Errorf("got success as false on delete network, error: %w", err)
 	}
 
 	return err

--- a/internal/cmp/router.go
+++ b/internal/cmp/router.go
@@ -113,31 +113,22 @@ func (r *router) Delete(ctx context.Context, d *utils.Data, meta interface{}) er
 func (r *router) routerAlignRouterRequest(ctx context.Context, meta interface{}, routerReq *models.CreateRouterRequest) error {
 	queryParam := make(map[string]string)
 	// Check whether teir0 or tier1 and assign properties to proper child, so json can marshal properly
+	tier0Config := routerReq.NetworkRouter.Config.CreateRouterTier0Config
 	if routerReq.NetworkRouter.TfTier0Config != nil {
-		routerReq.NetworkRouter.Config.CreateRouterTier0Config.RouteRedistributionTier0 =
-			routerReq.NetworkRouter.TfTier0Config.TfRRTier0
+		tier0Config.RouteRedistributionTier0 = routerReq.NetworkRouter.TfTier0Config.TfRRTier0
 
-		routerReq.NetworkRouter.Config.CreateRouterTier0Config.RouteRedistributionTier1 =
-			routerReq.NetworkRouter.TfTier0Config.TfRRTier1
-		routerReq.NetworkRouter.Config.CreateRouterTier0Config.RouteRedistributionTier1.RouteAdvertisement.TIER1DNSFORWARDERIP =
-			routerReq.NetworkRouter.TfTier0Config.TfRRTier1.TIER1DNSFORWARDERIP
-		routerReq.NetworkRouter.Config.CreateRouterTier0Config.RouteRedistributionTier1.RouteAdvertisement.TIER1LBSNAT =
-			routerReq.NetworkRouter.TfTier0Config.TfRRTier1.TIER1LBSNAT
-		routerReq.NetworkRouter.Config.CreateRouterTier0Config.RouteRedistributionTier1.RouteAdvertisement.TIER1NAT =
-			routerReq.NetworkRouter.TfTier0Config.TfRRTier1.TIER1NAT
-		routerReq.NetworkRouter.Config.CreateRouterTier0Config.RouteRedistributionTier1.RouteAdvertisement.TIER1LBVIP =
-			routerReq.NetworkRouter.TfTier0Config.TfRRTier1.TIER1LBVIP
-		routerReq.NetworkRouter.Config.CreateRouterTier0Config.RouteRedistributionTier1.RouteAdvertisement.TIER1IPSECLOCALENDPOINT =
-			routerReq.NetworkRouter.TfTier0Config.TfRRTier1.TIER1IPSECLOCALENDPOINT
-		routerReq.NetworkRouter.Config.CreateRouterTier0Config.RouteRedistributionTier1.RouteAdvertisement.TIER1STATIC =
-			routerReq.NetworkRouter.TfTier0Config.TfRRTier1.TIER1STATIC
-		routerReq.NetworkRouter.Config.CreateRouterTier0Config.RouteRedistributionTier1.RouteAdvertisement.Tier1Connected =
-			routerReq.NetworkRouter.TfTier0Config.TfRRTier1.Tier1Connected
-		routerReq.NetworkRouter.Config.CreateRouterTier0Config.RouteRedistributionTier1.RouteAdvertisement.Tier1StaticRoutes =
-			routerReq.NetworkRouter.TfTier0Config.TfRRTier1.Tier1StaticRoutes
+		tfRRTier1 := routerReq.NetworkRouter.TfTier0Config.TfRRTier1
+		tier0Config.RouteRedistributionTier1 = tfRRTier1
+		tier0Config.RouteRedistributionTier1.RouteAdvertisement.TIER1DNSFORWARDERIP = tfRRTier1.TIER1DNSFORWARDERIP
+		tier0Config.RouteRedistributionTier1.RouteAdvertisement.TIER1LBSNAT = tfRRTier1.TIER1LBSNAT
+		tier0Config.RouteRedistributionTier1.RouteAdvertisement.TIER1NAT = tfRRTier1.TIER1NAT
+		tier0Config.RouteRedistributionTier1.RouteAdvertisement.TIER1LBVIP = tfRRTier1.TIER1LBVIP
+		tier0Config.RouteRedistributionTier1.RouteAdvertisement.TIER1IPSECLOCALENDPOINT = tfRRTier1.TIER1IPSECLOCALENDPOINT
+		tier0Config.RouteRedistributionTier1.RouteAdvertisement.TIER1STATIC = tfRRTier1.TIER1STATIC
+		tier0Config.RouteRedistributionTier1.RouteAdvertisement.Tier1Connected = tfRRTier1.Tier1Connected
+		tier0Config.RouteRedistributionTier1.RouteAdvertisement.Tier1StaticRoutes = tfRRTier1.Tier1StaticRoutes
 
-		routerReq.NetworkRouter.Config.CreateRouterTier0Config.Bgp =
-			routerReq.NetworkRouter.TfTier0Config.TfBGP
+		tier0Config.Bgp = routerReq.NetworkRouter.TfTier0Config.TfBGP
 
 		routerReq.NetworkRouter.Config.HaMode = routerReq.NetworkRouter.TfTier0Config.TfHaMode
 		routerReq.NetworkRouter.Config.FailOver = routerReq.NetworkRouter.TfTier0Config.TfFailOver
@@ -145,8 +136,7 @@ func (r *router) routerAlignRouterRequest(ctx context.Context, meta interface{},
 		routerReq.NetworkRouter.EnableBGP = routerReq.NetworkRouter.TfTier0Config.TfBGP.TfEnableBgp
 		queryParam[nameKey] = tier0GatewayType
 	} else {
-		routerReq.NetworkRouter.Config.CreateRouterTier0Config.RouteRedistributionTier1.RouteAdvertisement =
-			routerReq.NetworkRouter.TfTier1Config.TfRouteAdvertisement
+		tier0Config.RouteRedistributionTier1.RouteAdvertisement = routerReq.NetworkRouter.TfTier1Config.TfRouteAdvertisement
 		routerReq.NetworkRouter.Config.EdgeCluster = routerReq.NetworkRouter.TfTier1Config.TfEdgeCluster
 		routerReq.NetworkRouter.Config.FailOver = routerReq.NetworkRouter.TfTier1Config.TfFailOver
 		routerReq.NetworkRouter.Config.Tier0Gateways = routerReq.NetworkRouter.TfTier1Config.TfTier0Gateways

--- a/internal/resources/diffValidation/resource_instances.go
+++ b/internal/resources/diffValidation/resource_instances.go
@@ -185,5 +185,6 @@ func (i *Instance) instanceValidateSnapshotDeletion() error {
 	if len(newMap) <= 0 {
 		return fmt.Errorf("deleting snapshot is not supported currently")
 	}
+
 	return nil
 }

--- a/internal/resources/diffValidation/resourse_router.go
+++ b/internal/resources/diffValidation/resourse_router.go
@@ -37,7 +37,7 @@ func (r *Router) DiffValidate() error {
 	return nil
 }
 
-func (r *Router) validateHAModeIsACTIVE_STANDBY() error {
+func (r *Router) validateHAModeIsActiveStandby() error {
 	// BGP inter SR routing only applicable for Tier0 in active-active HA-mode
 
 	if r.diff.HasChange(haModePath) || r.diff.HasChange(interSRiBGPPath) {
@@ -101,7 +101,7 @@ func (r *Router) validateBGPTimers() error {
 }
 
 func (r *Router) validateTier0Config() error {
-	err := r.validateHAModeIsACTIVE_STANDBY()
+	err := r.validateHAModeIsActiveStandby()
 	if err != nil {
 		return err
 	}

--- a/internal/utils/retry.go
+++ b/internal/utils/retry.go
@@ -102,7 +102,7 @@ func retry(
 				if i == cRetry.RetryCount-1 {
 					apiChan <- continueStruct{
 						respErr: fmt.Errorf(
-							"maximum retry limit reached, with Error: %#v, Response: %#v",
+							"maximum retry limit reached, with Error: %s, Response: %#v",
 							continueChan.respErr.Error(),
 							continueChan.resp,
 						),

--- a/internal/utils/retry.go
+++ b/internal/utils/retry.go
@@ -102,7 +102,7 @@ func retry(
 				if i == cRetry.RetryCount-1 {
 					apiChan <- continueStruct{
 						respErr: fmt.Errorf(
-							"maximum retry limit reached, with Error: %s, Response: %#v",
+							"maximum retry limit reached, with Error: %#v, Response: %#v",
 							continueChan.respErr.Error(),
 							continueChan.resp,
 						),

--- a/pkg/atf/reader.go
+++ b/pkg/atf/reader.go
@@ -125,17 +125,17 @@ func (r *reader) parseValidations(vip *viper.Viper, i int) []validation {
 	}
 	m := make([]validation, 0, len(vls))
 	for k, v := range vls {
-		kStr := k.(string)
-		kSplit := strings.Split(kStr, ".")
-		if len(kSplit) > 1 && (kSplit[0] == jsonKey || kSplit[0] == tfKey) {
+		str := k.(string)
+		split := strings.Split(str, ".")
+		if len(split) > 1 && (split[0] == jsonKey || split[0] == tfKey) {
 			isJSON := false
-			if kSplit[0] == jsonKey {
+			if split[0] == jsonKey {
 				isJSON = true
 			}
 
 			m = append(m, validation{
 				isJSON: isJSON,
-				key:    kStr[len(kSplit[0])+1:],
+				key:    str[len(split[0])+1:],
 				value:  v,
 			})
 		} else {

--- a/pkg/atf/reader.go
+++ b/pkg/atf/reader.go
@@ -124,19 +124,19 @@ func (r *reader) parseValidations(vip *viper.Viper, i int) []validation {
 		return nil
 	}
 	m := make([]validation, 0, len(vls))
-	for k, v := range vls {
-		str := k.(string)
-		split := strings.Split(str, ".")
-		if len(split) > 1 && (split[0] == jsonKey || split[0] == tfKey) {
+	for key, val := range vls {
+		keyStr := key.(string)
+		keySplit := strings.Split(keyStr, ".")
+		if len(keySplit) > 1 && (keySplit[0] == jsonKey || keySplit[0] == tfKey) {
 			isJSON := false
-			if split[0] == jsonKey {
+			if keySplit[0] == jsonKey {
 				isJSON = true
 			}
 
 			m = append(m, validation{
 				isJSON: isJSON,
-				key:    str[len(split[0])+1:],
-				value:  v,
+				key:    keyStr[len(keySplit[0])+1:],
+				value:  val,
 			})
 		} else {
 			r.fatalf("invalid validation format. validation format should be '[json|tf].key1.key2....keyn: value'")

--- a/pkg/utils/meta.go
+++ b/pkg/utils/meta.go
@@ -27,7 +27,6 @@ func SetMeta(apiClient *client.APIClient, r *schema.ResourceData) {
 			*ctx = context.WithValue(*ctx, client.ContextAccessToken, token)
 		}
 	})
-
 	if err != nil {
 		log.Printf("[WARN] Error: %s", err)
 	}


### PR DESCRIPTION
We have fixed few of the lint issues reported by the hpegl-provider team.

Currently we are disabling the following. Going forward, we should be fixing these one by one.
 # Temporarily disabling these
    - dupl
    - predeclared
    - paralleltest
    - gocritic
    - forcetypeassert
    - ifshort
    - exhaustivestruct
    - cyclop.
    - errorlint
    - varnamelen 
    - maintidx
    - ireturn