### PR TITLE
[DE8373] Plan reconfigure

### DIFF
--- a/internal/cmp/instance_helper.go
+++ b/internal/cmp/instance_helper.go
@@ -595,12 +595,21 @@ func instanceUpdateNetworkVolume(
 		if err := d.Error(); err != nil {
 			return err
 		}
+	} else if d.HasChanged("plan_id") {
+		resizeReq = models.ResizeInstanceBody{
+			Instance: &models.ResizeInstanceBodyInstance{
+				Plan: &models.ResizeInstanceBodyInstancePlan{
+					ID: d.GetInt("plan_id"),
+				},
+			},
+		}
 	}
+
 	if d.HasChanged("network") {
 		schemaNetwork := d.GetListMap("network")
 		resizeReq.NetworkInterfaces = instanceGetResizeNetwork(schemaNetwork)
 	}
-	if d.HasChanged("volume") || d.HasChanged("network") {
+	if d.HasChanged("volume") || d.HasChanged("network") || d.HasChanged("plan_id") {
 		updateResp, err := sharedClient.iClient.ResizeAnInstance(ctx, instanceID, &resizeReq)
 		if err != nil {
 			return err

--- a/internal/cmp/instance_helper.go
+++ b/internal/cmp/instance_helper.go
@@ -131,7 +131,7 @@ func updateInstance(ctx context.Context, sharedClient instanceSharedClient, d *u
 			return err
 		}
 	}
-	if err := instanceUpdateNetworkVolume(ctx, sharedClient, d, id); err != nil {
+	if err := instanceUpdateNetworkVolumePlan(ctx, sharedClient, d, id); err != nil {
 		return err
 	}
 
@@ -575,7 +575,7 @@ func instanceGetNetworkModel(
 	return networks, nil
 }
 
-func instanceUpdateNetworkVolume(
+func instanceUpdateNetworkVolumePlan(
 	ctx context.Context,
 	sharedClient instanceSharedClient,
 	d *utils.Data,

--- a/internal/resources/diffValidation/resource_instances.go
+++ b/internal/resources/diffValidation/resource_instances.go
@@ -24,7 +24,7 @@ func NewInstanceValidate(diff *schema.ResourceDiff) *Instance {
 }
 
 func (i *Instance) DiffValidate() error {
-	notAllowed := []string{"plan_id", "scale"}
+	notAllowed := []string{"scale"}
 
 	for _, param := range notAllowed {
 		if i.diff.HasChange(param) {

--- a/internal/resources/resource_instances_helper.go
+++ b/internal/resources/resource_instances_helper.go
@@ -102,7 +102,7 @@ func getInstanceDefaultSchema(isClone bool) *schema.Resource {
 						"is_primary": {
 							Type:        schema.TypeBool,
 							Computed:    true,
-							Description: `Flag to identify given network is primary or not. Primary network cannot be updated or deleted.`,
+							Description: `Flag to identify given network is primary or not. Primary network cannot be deleted.`,
 						},
 						"internal_id": {
 							Type:        schema.TypeInt,

--- a/internal/resources/resource_instances_helper.go
+++ b/internal/resources/resource_instances_helper.go
@@ -72,7 +72,6 @@ func getInstanceDefaultSchema(isClone bool) *schema.Resource {
 				Type:        schema.TypeInt,
 				Optional:    isClone,
 				Required:    !isClone,
-				ForceNew:    true,
 				Description: f(generalDDesc, "plan"),
 			},
 			"instance_type_code": {


### PR DESCRIPTION
## Description
- Requirement: Change of plan should not recreate the existing instance.
   Changes Made: 
   1) Remove 'force new' option 
   2) Earlier, change in volume also included the change in plan, so adding a separate option to change plan ( Note: If there is a change in volume then there is no need to separately run the change in plan code)