### PR TITLE
[5.4.3]Adding the filterType=Synced for Virtual Images

### DIFF
--- a/internal/cmp/constants.go
+++ b/internal/cmp/constants.go
@@ -16,10 +16,13 @@ const (
 	nameKey          = "name"
 	maxKey           = "max"
 	externalNameKey  = "externalName"
+	filterTypeKey    = "filterType"
 	// retry related constants
 	maxTimeout = time.Hour * 2
 	// router consts
 	tier0GatewayType             = "NSX-T Tier-0 Gateway"
 	tier1GatewayType             = "NSX-T Tier-1 Gateway"
 	routerFirewallExternalPolicy = "GatewayPolicy"
+
+	syncedTypeValue = "Synced"
 )

--- a/internal/cmp/template.go
+++ b/internal/cmp/template.go
@@ -30,7 +30,8 @@ func (t *template) Read(ctx context.Context, d *utils.Data, meta interface{}) er
 		return err
 	}
 	template, err := t.tClient.GetAllVirtualImages(ctx, map[string]string{
-		nameKey: name,
+		nameKey:       name,
+		filterTypeKey: syncedTypeValue,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
From 5.4.3, we need to pass `filterType=Synced` as a query param to get the Virtual Images.