### PR TITLE
Add API_URL as schema parameter

### DIFF
--- a/acc-testcases/README.md
+++ b/acc-testcases/README.md
@@ -20,6 +20,13 @@ export HPEGL_VMAAS_LOCATION=<vmaas_location>
 export HPEGL_VMAAS_SPACE_NAME=<vmaas_space_name>
 ```
 
+By default the Terraform Provider will use the VMaaS production endpoint. To
+use a non-production endpoint the `HPEGL_VMAAS_API_URL` must be set. For
+example:
+```bash
+export HPEGL_VMAAS_API_URL="https://iac-vmaas.intg.hpedevops.net"
+```
+
 By Default acceptance test will run test cases from folder `acc-testcases`.
 If you need to specify different test suite or folder, please set environment
 `TF_ACC_TEST_PATH`

--- a/internal/acceptance_test/helper.go
+++ b/internal/acceptance_test/helper.go
@@ -24,7 +24,7 @@ func getAPIClient() (*api_client.APIClient, api_client.Configuration) {
 	}
 
 	cfg := api_client.Configuration{
-		Host:          utils.GetServiceEndpoint(),
+		Host: os.Getenv("HPEGL_VMAAS_API_URL"),
 		DefaultHeader: headers,
 		DefaultQueryParams: map[string]string{
 			constants.LocationKey: os.Getenv("HPEGL_VMAAS_LOCATION"),

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -5,13 +5,12 @@ package constants
 
 const (
 	// ServiceName - the service mnemonic
-	ServiceName    = "vmaas"
-	DevServiceURL  = "https://iac-vmaas.dev.hpehcss.net"
-	IntgServiceURL = "https://iac-vmaas.intg.hpedevops.net"
-	ServiceURL     = "https://iac-vmaas.us1.greenlake-hpe.com"
+	ServiceName = "vmaas"
+	ServiceURL  = "https://iac-vmaas.us1.greenlake-hpe.com"
 
 	LOCATION    = "location"
 	SPACENAME   = "space_name"
+	APIURL      = "api_url"
 	INSECURE    = "allow_insecure"
 	SpaceKey    = "space"
 	LocationKey = "location"

--- a/pkg/resources/registration.go
+++ b/pkg/resources/registration.go
@@ -71,6 +71,12 @@ func (r Registration) ProviderSchemaEntry() *schema.Resource {
 				DefaultFunc: schema.EnvDefaultFunc("HPEGL_VMAAS_SPACE_NAME", ""),
 				Description: "IAM Space name of the GL VMaaS Service, can also be set with the HPEGL_VMAAS_SPACE_NAME env var.",
 			},
+			constants.APIURL: {
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("HPEGL_VMAAS_API_URL", constants.ServiceURL),
+				Description: "The URL to use for the VMaaS API, can also be set with the HPEGL_VMAAS_API_URL env var",
+			},
 		},
 	}
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	api_client "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/client"
-	"github.com/HewlettPackard/hpegl-vmaas-terraform-resources/pkg/constants"
 	"github.com/spf13/viper"
 )
 
@@ -76,15 +75,4 @@ func GetEnvBool(key string) bool {
 	}
 
 	return value
-}
-
-func GetServiceEndpoint() string {
-	switch os.Getenv("SERVICE_ACCOUNT") {
-	case "dev":
-		return constants.DevServiceURL
-	case "intg":
-		return constants.IntgServiceURL
-	}
-
-	return constants.ServiceURL
 }


### PR DESCRIPTION
The standard pattern for the hpegl Terraform provider is to
allow the API endpoint of a service to be configurable as a parameter
in the service section of the provider block of a Terraform config.
This changes brings the VMaaS provider in line with that pattern.
A sample Terraform config would now look like:

    provider "hpegl" {
      vmaas {
        location   = var.location
        space_name = var.space
        api_url = "https://iac-vmaas.intg.hpedevops.net"
      }
    }

If not provided the api_url will default to the VMaaS production endpoint.