### PR TITLE
US26069 : Documentation template for load balancer

### DIFF
--- a/internal/resources/resource_loadbalancer.go
+++ b/internal/resources/resource_loadbalancer.go
@@ -101,10 +101,9 @@ func LoadBalancer() *schema.Resource {
 							Description: `In Filter. Supported Values are "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "ALERT", "EMERGENCY"`,
 						},
 						"tier1_gateways": {
-							Type:     schema.TypeString,
-							Required: true,
-							Description: "Tier1 Gateway. Get the `providerId`. Use " + DSRouter +
-								"datasource to obtain the provider_id and nsx-t-tier1-gateway which indicates that it is a NSX-T Tier1 Gateway",
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Provider ID of the Tier1 Gateway. Use " + DSRouter + " datasource to obtain the provider_id here.",
 						},
 					},
 				},

--- a/internal/resources/resource_loadbalancer.go
+++ b/internal/resources/resource_loadbalancer.go
@@ -101,9 +101,10 @@ func LoadBalancer() *schema.Resource {
 							Description: `In Filter. Supported Values are "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "ALERT", "EMERGENCY"`,
 						},
 						"tier1_gateways": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "Tier1 Gateway. Get the `providerId`. Use " + DSRouter + " datasource to obtain the provider_id and nsx-t-tier1-gateway which indicates that it is a NSX T Tier1 Gateway",
+							Type:     schema.TypeString,
+							Required: true,
+							Description: "Tier1 Gateway. Get the `providerId`. Use " + DSRouter +
+								"datasource to obtain the provider_id and nsx-t-tier1-gateway which indicates that it is a NSX T Tier1 Gateway",
 						},
 					},
 				},

--- a/internal/resources/resource_loadbalancer.go
+++ b/internal/resources/resource_loadbalancer.go
@@ -103,7 +103,7 @@ func LoadBalancer() *schema.Resource {
 						"tier1_gateways": {
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "Provider ID of the Tier1 Gateway. Use " + DSRouter + " datasource to obtain the provider_id  here.",
+							Description: "Tier1 Gateway. Get the `providerId`. Use " + DSRouter + " datasource to obtain the provider_id and nsx-t-tier1-gateway which indicates that it is a NSX T Tier1 Gateway",
 						},
 					},
 				},

--- a/internal/resources/resource_loadbalancer.go
+++ b/internal/resources/resource_loadbalancer.go
@@ -104,7 +104,7 @@ func LoadBalancer() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 							Description: "Tier1 Gateway. Get the `providerId`. Use " + DSRouter +
-								"datasource to obtain the provider_id and nsx-t-tier1-gateway which indicates that it is a NSX T Tier1 Gateway",
+								"datasource to obtain the provider_id and nsx-t-tier1-gateway which indicates that it is a NSX-T Tier1 Gateway",
 						},
 					},
 				},

--- a/templates/resources/vmaas_load_balancer.md.tmpl
+++ b/templates/resources/vmaas_load_balancer.md.tmpl
@@ -13,6 +13,9 @@ description: |-
 {{ .Description | trimspace }}
 `hpegl_vmaas_load_balancer` resource supports NSX-T Load Balancer creation.
 
+-> It is mandatory to choose the `Tier1 Gateway` while creating the load balancer
+(for this purpose `hpegl_vmaas_router` can be used).
+
 -> Tier1 Gateway Data Source `hpegl_vmaas_router` is supported for NSX-T Load Balancer.
 
 ## Example usage for creating NSX-T Load Balancer with all possible attributes

--- a/templates/resources/vmaas_load_balancer.md.tmpl
+++ b/templates/resources/vmaas_load_balancer.md.tmpl
@@ -1,0 +1,22 @@
+---
+layout: ""
+page_title: "hpegl_vmaas_load_balancer Resource - vmaas-terraform-resources"
+subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+description: |-
+  {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+---
+
+# Resource hpegl_vmaas_load_balancer
+
+-> Compatible version >= 5.4.6
+
+{{ .Description | trimspace }}
+`hpegl_vmaas_load_balancer` resource supports NSX-T Load Balancer creation.
+
+-> Tier1 Gateway Data Source `hpegl_vmaas_router` is supported for NSX-T Load Balancer.
+
+## Example usage for creating NSX-T Load Balancer with all possible attributes
+
+{{tffile "examples/resources/hpegl_vmaas_load_balancer/nsx_t_lb.tf"}}
+
+{{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/vmaas_load_balancer.md.tmpl
+++ b/templates/resources/vmaas_load_balancer.md.tmpl
@@ -13,9 +13,6 @@ description: |-
 {{ .Description | trimspace }}
 `hpegl_vmaas_load_balancer` resource supports NSX-T Load Balancer creation.
 
--> It is mandatory to choose the `Tier1 Gateway` while creating the load balancer
-(for this purpose `hpegl_vmaas_router` can be used).
-
 ## Example usage for creating NSX-T Load Balancer with all possible attributes
 
 {{tffile "examples/resources/hpegl_vmaas_load_balancer/nsx_t_lb.tf"}}

--- a/templates/resources/vmaas_load_balancer.md.tmpl
+++ b/templates/resources/vmaas_load_balancer.md.tmpl
@@ -16,8 +16,6 @@ description: |-
 -> It is mandatory to choose the `Tier1 Gateway` while creating the load balancer
 (for this purpose `hpegl_vmaas_router` can be used).
 
--> Tier1 Gateway Data Source `hpegl_vmaas_router` is supported for NSX-T Load Balancer.
-
 ## Example usage for creating NSX-T Load Balancer with all possible attributes
 
 {{tffile "examples/resources/hpegl_vmaas_load_balancer/nsx_t_lb.tf"}}


### PR DESCRIPTION
---
layout: ""
page_title: "hpegl_vmaas_load_balancer Resource - vmaas-terraform-resources"
subcategory: "vmaas"
description: |-
    loadbalancer resource facilitates creating, updating
          and deleting NSX-T  Network Load Balancers.
---

# Resource hpegl_vmaas_load_balancer

-> Compatible version >= 5.4.6

loadbalancer resource facilitates creating, updating
		and deleting NSX-T  Network Load Balancers.
`hpegl_vmaas_load_balancer` resource supports NSX-T Load Balancer creation.

## Example usage for creating NSX-T Load Balancer with all possible attributes

```terraform
# (C) Copyright 2022 Hewlett Packard Enterprise Development LP

resource "hpegl_vmaas_load_balancer" "tf_lb" {
  name        = "tf_loadbalancer"
  description = "Loadbalancer created using tf"
  enabled     = true
  group_access {
    all = true
  }
  config {
    admin_state    = true
    size           = "SMALL"
    log_level      = "INFO"
    tier1_gateways = data.hpegl_vmaas_router.tier1_router.provider_id
  }
}
```

<!-- schema generated by tfplugindocs -->
## Schema

### Required

- `config` (Block List, Min: 1) Network Load Balancer Configuration (see [below for nested schema](#nestedblock--config))
- `name` (String) Network loadbalancer name

### Optional

- `description` (String) Creating the  Network loadbalancer
- `enabled` (Boolean) Pass `true` to allow for enabled and Pass `false` to disabled
- `group_access` (Block List, Max: 1) (see [below for nested schema](#nestedblock--group_access))

### Read-Only

- `id` (String) The ID of this resource.
- `lb_type` (String) Type of Network loadbalancer
- `network_server_id` (Number) NSX-T Integration ID

<a id="nestedblock--config"></a>
### Nested Schema for `config`

Required:

- `tier1_gateways` (String) Provider ID of the Tier1 Gateway. Use hpegl_vmaas_router datasource to obtain the provider_id here.

Optional:

- `admin_state` (Boolean) If `true` then admin State rule will be active/enabled.
- `log_level` (String) In Filter. Supported Values are "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "ALERT", "EMERGENCY"
- `size` (String) In Filter. Supported Values are "SMALL", "MEDIUM", "LARGE"


<a id="nestedblock--group_access"></a>
### Nested Schema for `group_access`

Optional:

- `all` (Boolean) Pass `true` to allow access to all groups.
- `sites` (Block List) List of sites/groups (see [below for nested schema](#nestedblock--group_access--sites))

<a id="nestedblock--group_access--sites"></a>
### Nested Schema for `group_access.sites`

Optional:

- `default` (Boolean) Group Default Selection
- `id` (Number) ID of the site/group