### PR TITLE
Documentation template for load balancer Monitor

### DIFF
--- a/internal/resources/resource_lb_monitors.go
+++ b/internal/resources/resource_lb_monitors.go
@@ -59,7 +59,7 @@ func LoadBalancerMonitor() *schema.Resource {
 		DeleteContext: loadbalancerMonitorDeleteContext,
 		CustomizeDiff: monitorCustomDiff,
 		Description: `Loadbalancer Monitor resource facilitates creating, updating
-		and deleting NSX-T Network Load Balancer Monitors.`,
+		and deleting NSX-T Network Load Balancer Monitors. `,
 	}
 }
 

--- a/internal/resources/resource_lb_monitors.go
+++ b/internal/resources/resource_lb_monitors.go
@@ -58,7 +58,7 @@ func LoadBalancerMonitor() *schema.Resource {
 		CreateContext: loadbalancerMonitorCreateContext,
 		DeleteContext: loadbalancerMonitorDeleteContext,
 		CustomizeDiff: monitorCustomDiff,
-		Description: `loadbalancer Monitor resource facilitates creating,updating
+		Description: `Loadbalancer Monitor resource facilitates creating,updating
 		and deleting NSX-T Network Load Balancers.`,
 	}
 }

--- a/internal/resources/resource_lb_monitors.go
+++ b/internal/resources/resource_lb_monitors.go
@@ -59,7 +59,7 @@ func LoadBalancerMonitor() *schema.Resource {
 		DeleteContext: loadbalancerMonitorDeleteContext,
 		CustomizeDiff: monitorCustomDiff,
 		Description: `Loadbalancer Monitor resource facilitates creating,updating
-		and deleting NSX-T Network Load Balancers.`,
+		and deleting NSX-T Network Load Balancer Monitors.`,
 	}
 }
 

--- a/internal/resources/resource_lb_monitors.go
+++ b/internal/resources/resource_lb_monitors.go
@@ -58,7 +58,7 @@ func LoadBalancerMonitor() *schema.Resource {
 		CreateContext: loadbalancerMonitorCreateContext,
 		DeleteContext: loadbalancerMonitorDeleteContext,
 		CustomizeDiff: monitorCustomDiff,
-		Description: `Loadbalancer Monitor resource facilitates creating,updating
+		Description: `Loadbalancer Monitor resource facilitates creating, updating
 		and deleting NSX-T Network Load Balancer Monitors.`,
 	}
 }

--- a/internal/resources/schemas/lb_monitor_schemas.go
+++ b/internal/resources/schemas/lb_monitor_schemas.go
@@ -37,12 +37,12 @@ func HTTPMonitorSchema() *schema.Schema {
 				"interval": {
 					Type:        schema.TypeInt,
 					Default:     5,
-					Description: "The frequency at which the system issues the monitor check (in seconds).",
+					Description: "Set the number of times the server is tested before it is considered as DOWN",
 					Optional:    true,
 				},
 				"monitor_port": {
 					Type:        schema.TypeInt,
-					Description: "If the monitor port is specified, it would override pool member port setting for healthcheck",
+					Description: "Set the value of the monitoring port.",
 					Optional:    true,
 				},
 				"rise_count": {
@@ -55,11 +55,11 @@ func HTTPMonitorSchema() *schema.Schema {
 					Type:        schema.TypeInt,
 					Optional:    true,
 					Default:     15,
-					Description: "The frequency at which the system issues the monitor check",
+					Description: "Set the number of times the server is tested before it is considered as DOWN",
 				},
 				"request_body": {
 					Type:        schema.TypeString,
-					Description: "String to send as HTTP health check request body. Valid only for certain HTTP methods like POST",
+					Description: "Enter the request body. Valid for the POST and PUT methods",
 					Optional:    true,
 				},
 				"request_method": {
@@ -73,7 +73,7 @@ func HTTPMonitorSchema() *schema.Schema {
 						"PUT",
 					}, false),
 					Default:     "GET",
-					Description: "Health check method for HTTP monitor type. Valid values are GET, HEAD, PUT, POST and OPTIONS",
+					Description: "Select the method to detect the server status",
 				},
 				"request_url": {
 					Type:        schema.TypeString,
@@ -90,14 +90,16 @@ func HTTPMonitorSchema() *schema.Schema {
 					Optional:    true,
 				},
 				"response_data": {
-					Type:        schema.TypeString,
-					Description: "Response data to get the monitor data",
-					Optional:    true,
+					Type: schema.TypeString,
+					Description: "If the HTTP response body string and the HTTP health check response body match," +
+						"then the server is considered as healthy",
+					Optional: true,
 				},
 				"response_status_codes": {
-					Type:        schema.TypeString,
-					Description: "HTTP response status code should be a valid HTTP status code",
-					Optional:    true,
+					Type: schema.TypeString,
+					Description: "Enter the string that the monitor expects to match in the status line of HTTP response body." +
+						"The response code is a comma-separated list",
+					Optional: true,
 				},
 			},
 		},
@@ -136,12 +138,12 @@ func HTTPSMonitorSchema() *schema.Schema {
 				"interval": {
 					Type:        schema.TypeInt,
 					Default:     5,
-					Description: "The frequency at which the system issues the monitor check (in seconds).",
+					Description: "Set the number of times the server is tested before it is considered as DOWN",
 					Optional:    true,
 				},
 				"monitor_port": {
 					Type:        schema.TypeInt,
-					Description: "If the monitor port is specified, it would override pool member port setting for healthcheck.",
+					Description: "Set the value of the monitoring port",
 					Optional:    true,
 				},
 				"rise_count": {
@@ -154,11 +156,11 @@ func HTTPSMonitorSchema() *schema.Schema {
 					Type:        schema.TypeInt,
 					Optional:    true,
 					Default:     15,
-					Description: "The frequency at which the system issues the monitor check",
+					Description: "Set the number of times the server is tested before it is considered as DOWN",
 				},
 				"request_body": {
 					Type:        schema.TypeString,
-					Description: "String to send as HTTPs health check request body. Valid only for certain HTTPs methods like POST",
+					Description: "Enter the request body. Valid for the POST and PUT methods",
 					Optional:    true,
 				},
 				"request_method": {
@@ -172,7 +174,7 @@ func HTTPSMonitorSchema() *schema.Schema {
 						"PUT",
 					}, false),
 					Default:     "GET",
-					Description: "Health check method for HTTPs monitor type. Valid values are GET, HEAD, PUT, POST and OPTIONS",
+					Description: "Select the method to detect the server status",
 				},
 				"request_url": {
 					Type:        schema.TypeString,
@@ -189,14 +191,16 @@ func HTTPSMonitorSchema() *schema.Schema {
 					Optional:    true,
 				},
 				"response_data": {
-					Type:        schema.TypeString,
-					Description: "response data to get the monitor data",
-					Optional:    true,
+					Type: schema.TypeString,
+					Description: "If the HTTP response body string and the HTTP health check response body match," +
+						"then the server is considered as healthy",
+					Optional: true,
 				},
 				"response_status_codes": {
-					Type:        schema.TypeString,
-					Description: "HTTPs response status code should be a valid HTTPs status code",
-					Optional:    true,
+					Type: schema.TypeString,
+					Description: "Enter the string that the monitor expects to match in the status line of HTTP response body." +
+						"The response code is a comma-separated list",
+					Optional: true,
 				},
 			},
 		},
@@ -230,17 +234,17 @@ func IcmpMonitorSchema() *schema.Schema {
 					Type:        schema.TypeInt,
 					Optional:    true,
 					Default:     3,
-					Description: "Number of consecutive checks that must fail before marking it down.",
+					Description: "Number of consecutive checks that must fail before marking it down",
 				},
 				"interval": {
 					Type:        schema.TypeInt,
 					Default:     5,
-					Description: "The frequency at which the system issues the monitor check (in seconds).",
+					Description: "Set the number of times the server is tested before it is considered as DOWN",
 					Optional:    true,
 				},
 				"monitor_port": {
 					Type:        schema.TypeInt,
-					Description: "If the monitor port is specified, it would override pool member port setting for healthcheck",
+					Description: "Set the value of the monitoring port.",
 					Optional:    true,
 				},
 				"rise_count": {
@@ -254,12 +258,12 @@ func IcmpMonitorSchema() *schema.Schema {
 					Type:        schema.TypeInt,
 					Optional:    true,
 					Default:     15,
-					Description: "The frequency at which the system issues the monitor check",
+					Description: "Set the number of times the server is tested before it is considered as DOWN",
 				},
 				"data_length": {
 					Type:        schema.TypeInt,
 					Default:     56,
-					Description: "Data length is for the ICMP monitor type",
+					Description: "Maximum size of the ICMP data packet",
 					Optional:    true,
 				},
 			},
@@ -294,13 +298,14 @@ func PassiveMonitorSchema() *schema.Schema {
 					Type:        schema.TypeInt,
 					Optional:    true,
 					Default:     15,
-					Description: "The frequency at which the system issues the monitor check",
+					Description: "Set the number of times the server is tested before it is considered as DOWN",
 				},
 				"max_fail": {
-					Type:        schema.TypeInt,
-					Default:     5,
-					Description: "Maximum failure for the Passive monitor type",
-					Optional:    true,
+					Type:    schema.TypeInt,
+					Default: 5,
+					Description: "Set a value when the consecutive failures reach this value," +
+						"the server is considered temporarily unavailable",
+					Optional: true,
 				},
 			},
 		},
@@ -339,12 +344,12 @@ func TCPMonitorSchema() *schema.Schema {
 				"interval": {
 					Type:        schema.TypeInt,
 					Default:     5,
-					Description: "The frequency at which the system issues the monitor check (in seconds).",
+					Description: "Set the number of times the server is tested before it is considered as DOWN",
 					Optional:    true,
 				},
 				"monitor_port": {
 					Type:        schema.TypeInt,
-					Description: "If the monitor port is specified, it would override pool member port setting for healthcheck",
+					Description: "Set the value of the monitoring port.",
 					Optional:    true,
 				},
 				"rise_count": {
@@ -357,17 +362,18 @@ func TCPMonitorSchema() *schema.Schema {
 					Type:        schema.TypeInt,
 					Optional:    true,
 					Default:     15,
-					Description: "The frequency at which the system issues the monitor check",
+					Description: "Set the number of times the server is tested before it is considered as DOWN",
 				},
 				"request_body": {
 					Type:        schema.TypeString,
-					Description: "String to send as TCP health check request body. Valid only for certain TCP methods like POST",
+					Description: "Enter the request body. Valid for the POST and PUT methods",
 					Optional:    true,
 				},
 				"response_data": {
-					Type:        schema.TypeString,
-					Description: "Response data to get the monitor data",
-					Optional:    true,
+					Type: schema.TypeString,
+					Description: "If the HTTP response body string and the HTTP health check response body match" +
+						"then the server is considered as healthy",
+					Optional: true,
 				},
 			},
 		},
@@ -406,12 +412,12 @@ func UDPMonitorSchema() *schema.Schema {
 				"interval": {
 					Type:        schema.TypeInt,
 					Default:     5,
-					Description: "The frequency at which the system issues the monitor check (in seconds).",
+					Description: "Set the number of times the server is tested before it is considered as DOWN",
 					Optional:    true,
 				},
 				"monitor_port": {
 					Type:        schema.TypeInt,
-					Description: "If the monitor port is specified, it would override pool member port setting for healthcheck",
+					Description: "Set the value of the monitoring port.",
 					Optional:    true,
 				},
 				"rise_count": {
@@ -424,17 +430,18 @@ func UDPMonitorSchema() *schema.Schema {
 					Type:        schema.TypeInt,
 					Optional:    true,
 					Default:     15,
-					Description: "The frequency at which the system issues the monitor check",
+					Description: "Set the number of times the server is tested before it is considered as DOWN",
 				},
 				"request_body": {
 					Type:        schema.TypeString,
-					Description: "String to send as UDP health check request body. Valid only for certain UDP methods like POST",
+					Description: "Enter the request body. Valid for the POST and PUT methods",
 					Optional:    true,
 				},
 				"response_data": {
-					Type:        schema.TypeString,
-					Description: "Response data to get the monitor data",
-					Optional:    true,
+					Type: schema.TypeString,
+					Description: "If the HTTP response body string and the HTTP health check response body match," +
+						"then the server is considered as healthy",
+					Optional: true,
 				},
 			},
 		},

--- a/internal/resources/schemas/lb_monitor_schemas.go
+++ b/internal/resources/schemas/lb_monitor_schemas.go
@@ -42,7 +42,7 @@ func HTTPMonitorSchema() *schema.Schema {
 				},
 				"monitor_port": {
 					Type:        schema.TypeInt,
-					Description: "Interval time for Network loadbalancer Monitor",
+					Description: "If the monitor port is specified, it would override pool member port setting for healthcheck",
 					Optional:    true,
 				},
 				"rise_count": {
@@ -55,7 +55,7 @@ func HTTPMonitorSchema() *schema.Schema {
 					Type:        schema.TypeInt,
 					Optional:    true,
 					Default:     15,
-					Description: "Timeout for Network loadbalancer Monitor",
+					Description: "The frequency at which the system issues the monitor check",
 				},
 				"request_body": {
 					Type:        schema.TypeString,
@@ -77,7 +77,7 @@ func HTTPMonitorSchema() *schema.Schema {
 				},
 				"request_url": {
 					Type:        schema.TypeString,
-					Description: "URL used for HTTP monitor",
+					Description: "Enter the request URI for the method",
 					Optional:    true,
 				},
 				"request_version": {
@@ -91,7 +91,7 @@ func HTTPMonitorSchema() *schema.Schema {
 				},
 				"response_data": {
 					Type:        schema.TypeString,
-					Description: "response data to get the monitor data",
+					Description: "Response data to get the monitor data",
 					Optional:    true,
 				},
 				"response_status_codes": {
@@ -154,7 +154,7 @@ func HTTPSMonitorSchema() *schema.Schema {
 					Type:        schema.TypeInt,
 					Optional:    true,
 					Default:     15,
-					Description: "Number of seconds the target has to respond to the monitor request",
+					Description: "The frequency at which the system issues the monitor check",
 				},
 				"request_body": {
 					Type:        schema.TypeString,
@@ -176,7 +176,7 @@ func HTTPSMonitorSchema() *schema.Schema {
 				},
 				"request_url": {
 					Type:        schema.TypeString,
-					Description: "URL used for HTTP monitor",
+					Description: "Enter the request URI for the method",
 					Optional:    true,
 				},
 				"request_version": {
@@ -254,12 +254,12 @@ func IcmpMonitorSchema() *schema.Schema {
 					Type:        schema.TypeInt,
 					Optional:    true,
 					Default:     15,
-					Description: "Number of seconds the target has to respond to the monitor request",
+					Description: "The frequency at which the system issues the monitor check",
 				},
 				"data_length": {
 					Type:        schema.TypeInt,
 					Default:     56,
-					Description: "data length is for the ICMP monitor type",
+					Description: "Data length is for the ICMP monitor type",
 					Optional:    true,
 				},
 			},
@@ -294,12 +294,12 @@ func PassiveMonitorSchema() *schema.Schema {
 					Type:        schema.TypeInt,
 					Optional:    true,
 					Default:     15,
-					Description: "Number of seconds the target has to respond to the monitor request",
+					Description: "The frequency at which the system issues the monitor check",
 				},
 				"max_fail": {
 					Type:        schema.TypeInt,
 					Default:     5,
-					Description: "maximum failure for the ICMP monitor type",
+					Description: "Maximum failure for the Passive monitor type",
 					Optional:    true,
 				},
 			},
@@ -357,7 +357,7 @@ func TCPMonitorSchema() *schema.Schema {
 					Type:        schema.TypeInt,
 					Optional:    true,
 					Default:     15,
-					Description: "Number of seconds the target has to respond to the monitor request",
+					Description: "The frequency at which the system issues the monitor check",
 				},
 				"request_body": {
 					Type:        schema.TypeString,
@@ -366,7 +366,7 @@ func TCPMonitorSchema() *schema.Schema {
 				},
 				"response_data": {
 					Type:        schema.TypeString,
-					Description: "response data to get the monitor data",
+					Description: "Response data to get the monitor data",
 					Optional:    true,
 				},
 			},
@@ -424,7 +424,7 @@ func UDPMonitorSchema() *schema.Schema {
 					Type:        schema.TypeInt,
 					Optional:    true,
 					Default:     15,
-					Description: "Number of seconds the target has to respond to the monitor request",
+					Description: "The frequency at which the system issues the monitor check",
 				},
 				"request_body": {
 					Type:        schema.TypeString,
@@ -433,7 +433,7 @@ func UDPMonitorSchema() *schema.Schema {
 				},
 				"response_data": {
 					Type:        schema.TypeString,
-					Description: "response data to get the monitor data",
+					Description: "Response data to get the monitor data",
 					Optional:    true,
 				},
 			},

--- a/templates/resources/vmaas_load_balancer_monitor.md.tmpl
+++ b/templates/resources/vmaas_load_balancer_monitor.md.tmpl
@@ -15,59 +15,39 @@ description: |-
 
 For creating an NSX-T Load balancer Monitor, use the following examples.
 
--> NSX-T Monitor having HTTP,HTTPS,ICMP,Passive,TCP,UDP  considered as different monitor types. You can create either HTTP,HTTPS,ICMP,Passive,TCP,UDP, but not everything at the same time.
-
 -> Load Balancer ID Data Source `hpegl_vmaas_load_balancer` is supported for Creating Monitor.
-
 
 ## Example usage for creating NSX-T Load balancer Monitor for HTTP with all possible attributes
 
 -> For NSX-T Load balancer Monitor for HTTP creation, attribute monitorType value `LBHttpMonitorProfile` is applicable only HTTP creation.
 
--> Once NSX-T Load balancer Monitor for HTTP created with `LBHttpMonitorProfile`, we can not modify the attribute during the update operation and its disabled from UI.
-
 {{tffile "examples/resources/hpegl_vmaas_load_balancer_monitor/nsx_t_lb_http_monitor.tf"}}
 
-
 ## Example usage for creating NSX-T Load balancer Monitor for HTTPS with all possible attributes
-
--> For NSX-T Load balancer Monitor for HTTPS creation, attribute monitorType value `LBHttpsMonitorProfile` is applicable only HTTPS creation.
 
 -> Once NSX-T Load balancer Monitor for HTTPs created with `LBHttpsMonitorProfile`, we can not modify the attribute during the update operation and its disabled from UI.
 
 {{tffile "examples/resources/hpegl_vmaas_load_balancer_monitor/nsx_t_lb_https_monitor.tf"}}
 
-
 ## Example usage for creating NSX-T Load balancer Monitor for ICMP with all possible attributes
-
--> For NSX-T Load balancer Monitor for ICMP creation, attribute monitorType value `LBIcmpMonitorProfile` is applicable only ICMP creation.
 
 -> Once NSX-T Load balancer Monitor for ICMP created with `LBIcmpMonitorProfile`, we can not modify the attribute during the update operation and its disabled from UI.
 
 {{tffile "examples/resources/hpegl_vmaas_load_balancer_monitor/nsx_t_lb_icmp_monitor.tf"}}
 
-
 ## Example usage for creating NSX-T Load balancer Monitor for Passive with all possible attributes
-
--> For NSX-T Load balancer Monitor for Passive creation, attribute monitorType value `LBPassiveMonitorProfile` is applicable only Passive creation.
 
 -> Once NSX-T Load balancer Monitor for Passive created with `LBPassiveMonitorProfile`, we can not modify the attribute during the update operation and its disabled from UI.
 
 {{tffile "examples/resources/hpegl_vmaas_load_balancer_monitor/nsx_t_lb_passive_monitor.tf"}}
 
-
 ## Example usage for creating NSX-T Load balancer Monitor for TCP with all possible attributes
-
--> For NSX-T Load balancer Monitor for TCP creation, attribute monitorType value `LBTcpMonitorProfile` is applicable only TCP creation.
 
 -> Once NSX-T Load balancer Monitor for TCP created with `LBTcpMonitorProfile`, we can not modify the attribute during the update operation and its disabled from UI.
 
 {{tffile "examples/resources/hpegl_vmaas_load_balancer_monitor/nsx_t_lb_tcp_monitor.tf"}}
 
-
 ## Example usage for creating NSX-T Load balancer Monitor for UDP with all possible attributes
-
--> For NSX-T Load balancer Monitor for UDP creation, attribute monitorType value `LBUdpMonitorProfile` is applicable only UDP creation.
 
 -> Once NSX-T Load balancer Monitor for UDP created with `LBUdpMonitorProfile`, we can not modify the attribute during the update operation and its disabled from UI.
 

--- a/templates/resources/vmaas_load_balancer_monitor.md.tmpl
+++ b/templates/resources/vmaas_load_balancer_monitor.md.tmpl
@@ -17,37 +17,25 @@ For creating an NSX-T Load balancer Monitor, use the following examples.
 
 ## Example usage for creating NSX-T Load balancer Monitor for HTTP with all possible attributes
 
--> For NSX-T Load balancer Monitor for HTTP creation, attribute monitorType value `LBHttpMonitorProfile` is applicable only HTTP creation.
-
 {{tffile "examples/resources/hpegl_vmaas_load_balancer_monitor/nsx_t_lb_http_monitor.tf"}}
 
 ## Example usage for creating NSX-T Load balancer Monitor for HTTPS with all possible attributes
-
--> Once NSX-T Load balancer Monitor for HTTPs created with `LBHttpsMonitorProfile`, we can not modify the attribute during the update operation and its disabled from UI.
 
 {{tffile "examples/resources/hpegl_vmaas_load_balancer_monitor/nsx_t_lb_https_monitor.tf"}}
 
 ## Example usage for creating NSX-T Load balancer Monitor for ICMP with all possible attributes
 
--> Once NSX-T Load balancer Monitor for ICMP created with `LBIcmpMonitorProfile`, we can not modify the attribute during the update operation and its disabled from UI.
-
 {{tffile "examples/resources/hpegl_vmaas_load_balancer_monitor/nsx_t_lb_icmp_monitor.tf"}}
 
 ## Example usage for creating NSX-T Load balancer Monitor for Passive with all possible attributes
-
--> Once NSX-T Load balancer Monitor for Passive created with `LBPassiveMonitorProfile`, we can not modify the attribute during the update operation and its disabled from UI.
 
 {{tffile "examples/resources/hpegl_vmaas_load_balancer_monitor/nsx_t_lb_passive_monitor.tf"}}
 
 ## Example usage for creating NSX-T Load balancer Monitor for TCP with all possible attributes
 
--> Once NSX-T Load balancer Monitor for TCP created with `LBTcpMonitorProfile`, we can not modify the attribute during the update operation and its disabled from UI.
-
 {{tffile "examples/resources/hpegl_vmaas_load_balancer_monitor/nsx_t_lb_tcp_monitor.tf"}}
 
 ## Example usage for creating NSX-T Load balancer Monitor for UDP with all possible attributes
-
--> Once NSX-T Load balancer Monitor for UDP created with `LBUdpMonitorProfile`, we can not modify the attribute during the update operation and its disabled from UI.
 
 {{tffile "examples/resources/hpegl_vmaas_load_balancer_monitor/nsx_t_lb_udp_monitor.tf"}}
 

--- a/templates/resources/vmaas_load_balancer_monitor.md.tmpl
+++ b/templates/resources/vmaas_load_balancer_monitor.md.tmpl
@@ -1,0 +1,76 @@
+---
+layout: ""
+page_title: "hpegl_vmaas_load_balancer_monitor Resource - vmaas-terraform-resources"
+subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+description: |-
+  {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+---
+
+# Resource hpegl_vmaas_load_balancer_monitor
+
+-> Compatible version >= 5.4.6
+
+{{ .Description | trimspace }}
+`hpegl_vmaas_load_balancer_monitor` resource supports NSX-T Load balancer Monitor creation.
+
+For creating an NSX-T Load balancer Monitor, use the following examples.
+
+-> NSX-T Monitor having HTTP,HTTPS,ICMP,Passive,TCP,UDP  considered as different monitor types. You can create either HTTP,HTTPS,ICMP,Passive,TCP,UDP, but not everything at the same time.
+
+-> Load Balancer ID Data Source `hpegl_vmaas_load_balancer` is supported for Creating Monitor.
+
+
+## Example usage for creating NSX-T Load balancer Monitor for HTTP with all possible attributes
+
+-> For NSX-T Load balancer Monitor for HTTP creation, attribute monitorType value `LBHttpMonitorProfile` is applicable only HTTP creation.
+
+-> Once NSX-T Load balancer Monitor for HTTP created with `LBHttpMonitorProfile`, we can not modify the attribute during the update operation and its disabled from UI.
+
+{{tffile "examples/resources/hpegl_vmaas_load_balancer_monitor/nsx_t_lb_http_monitor.tf"}}
+
+
+## Example usage for creating NSX-T Load balancer Monitor for HTTPS with all possible attributes
+
+-> For NSX-T Load balancer Monitor for HTTPS creation, attribute monitorType value `LBHttpsMonitorProfile` is applicable only HTTPS creation.
+
+-> Once NSX-T Load balancer Monitor for HTTPs created with `LBHttpsMonitorProfile`, we can not modify the attribute during the update operation and its disabled from UI.
+
+{{tffile "examples/resources/hpegl_vmaas_load_balancer_monitor/nsx_t_lb_https_monitor.tf"}}
+
+
+## Example usage for creating NSX-T Load balancer Monitor for ICMP with all possible attributes
+
+-> For NSX-T Load balancer Monitor for ICMP creation, attribute monitorType value `LBIcmpMonitorProfile` is applicable only ICMP creation.
+
+-> Once NSX-T Load balancer Monitor for ICMP created with `LBIcmpMonitorProfile`, we can not modify the attribute during the update operation and its disabled from UI.
+
+{{tffile "examples/resources/hpegl_vmaas_load_balancer_monitor/nsx_t_lb_icmp_monitor.tf"}}
+
+
+## Example usage for creating NSX-T Load balancer Monitor for Passive with all possible attributes
+
+-> For NSX-T Load balancer Monitor for Passive creation, attribute monitorType value `LBPassiveMonitorProfile` is applicable only Passive creation.
+
+-> Once NSX-T Load balancer Monitor for Passive created with `LBPassiveMonitorProfile`, we can not modify the attribute during the update operation and its disabled from UI.
+
+{{tffile "examples/resources/hpegl_vmaas_load_balancer_monitor/nsx_t_lb_passive_monitor.tf"}}
+
+
+## Example usage for creating NSX-T Load balancer Monitor for TCP with all possible attributes
+
+-> For NSX-T Load balancer Monitor for TCP creation, attribute monitorType value `LBTcpMonitorProfile` is applicable only TCP creation.
+
+-> Once NSX-T Load balancer Monitor for TCP created with `LBTcpMonitorProfile`, we can not modify the attribute during the update operation and its disabled from UI.
+
+{{tffile "examples/resources/hpegl_vmaas_load_balancer_monitor/nsx_t_lb_tcp_monitor.tf"}}
+
+
+## Example usage for creating NSX-T Load balancer Monitor for UDP with all possible attributes
+
+-> For NSX-T Load balancer Monitor for UDP creation, attribute monitorType value `LBUdpMonitorProfile` is applicable only UDP creation.
+
+-> Once NSX-T Load balancer Monitor for UDP created with `LBUdpMonitorProfile`, we can not modify the attribute during the update operation and its disabled from UI.
+
+{{tffile "examples/resources/hpegl_vmaas_load_balancer_monitor/nsx_t_lb_udp_monitor.tf"}}
+
+{{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/vmaas_load_balancer_monitor.md.tmpl
+++ b/templates/resources/vmaas_load_balancer_monitor.md.tmpl
@@ -15,8 +15,6 @@ description: |-
 
 For creating an NSX-T Load balancer Monitor, use the following examples.
 
--> Load Balancer ID Data Source `hpegl_vmaas_load_balancer` is supported for Creating Monitor.
-
 ## Example usage for creating NSX-T Load balancer Monitor for HTTP with all possible attributes
 
 -> For NSX-T Load balancer Monitor for HTTP creation, attribute monitorType value `LBHttpMonitorProfile` is applicable only HTTP creation.


### PR DESCRIPTION
---
layout: ""
page_title: "hpegl_vmaas_load_balancer_monitor Resource - vmaas-terraform-resources"
subcategory: "vmaas"
description: |-
    Loadbalancer Monitor resource facilitates creating, updating
          and deleting NSX-T Network Load Balancer Monitors.
---

# Resource hpegl_vmaas_load_balancer_monitor

-> Compatible version >= 5.4.6

Loadbalancer Monitor resource facilitates creating, updating
		and deleting NSX-T Network Load Balancer Monitors.
`hpegl_vmaas_load_balancer_monitor` resource supports NSX-T Load balancer Monitor creation.

For creating an NSX-T Load balancer Monitor, use the following examples.

## Example usage for creating NSX-T Load balancer Monitor for HTTP with all possible attributes

```terraform
# (C) Copyright 2022 Hewlett Packard Enterprise Development LP

# HTTP Monitor
resource "hpegl_vmaas_load_balancer_monitor" "tf_HTTP_MONITOR" {
  lb_id       = data.hpegl_vmaas_load_balancer.tf_lb.id
  name        = "tf_HTTP_MONITOR"
  description = "HTTP_MONITOR creating using tf"
  type        = "LBHttpMonitorProfile"
  http_monitor {
    fall_count            = 8
    interval              = 10
    monitor_port          = 50
    rise_count            = 5
    timeout               = 30
    request_body          = "request input body data"
    request_method        = "GET"
    request_url           = "https://request.com"
    request_version       = "HTTP_VERSION_1_0"
    response_data         = "Failed"
    response_status_codes = "500"
  }
}
```

## Example usage for creating NSX-T Load balancer Monitor for HTTPS with all possible attributes

```terraform
# (C) Copyright 2022 Hewlett Packard Enterprise Development LP

# HTTPS Monitor
resource "hpegl_vmaas_load_balancer_monitor" "tf_HTTPS_MONITOR" {
  lb_id       = data.hpegl_vmaas_load_balancer.tf_lb.id
  name        = "tf_HTTPS_MONITOR"
  description = "HTTPS_MONITOR creating using tf"
  type        = "LBHttpsMonitorProfile"
  https_monitor {
    fall_count            = 3
    interval              = 5
    monitor_port          = 80
    rise_count            = 3
    timeout               = 15
    request_body          = "request input body data"
    request_method        = "GET"
    request_url           = "https://test.com"
    request_version       = "HTTP_VERSION_1_1"
    response_data         = "success"
    response_status_codes = "201,200"
  }
}
```

## Example usage for creating NSX-T Load balancer Monitor for ICMP with all possible attributes

```terraform
# (C) Copyright 2022 Hewlett Packard Enterprise Development LP

# ICMP Monitor
resource "hpegl_vmaas_load_balancer_monitor" "tf_ICMP_MONITOR" {
  lb_id       = data.hpegl_vmaas_load_balancer.tf_lb.id
  name        = "tf_ICMP_MONITOR"
  description = "ICMP_MONITOR update using tf"
  type        = "LBIcmpMonitorProfile"
  icmp_monitor {
    fall_count   = 30
    interval     = 50
    monitor_port = 8
    rise_count   = 3
    timeout      = 15
    data_length  = 32
  }
}
```

## Example usage for creating NSX-T Load balancer Monitor for Passive with all possible attributes

```terraform
# (C) Copyright 2022 Hewlett Packard Enterprise Development LP

# PASSIVE Monitor
resource "hpegl_vmaas_load_balancer_monitor" "tf_PASSIVE_MONITOR" {
  lb_id       = data.hpegl_vmaas_load_balancer.tf_lb.id
  name        = "tf_PASSIVE_MONITOR"
  description = "PASSIVE_MONITOR create using tf"
  type        = "LBPassiveMonitorProfile"
  passive_monitor {
    timeout  = 15
    max_fail = 5
  }
}
```

## Example usage for creating NSX-T Load balancer Monitor for TCP with all possible attributes

```terraform
# (C) Copyright 2022 Hewlett Packard Enterprise Development LP

# TCP Monitor
resource "hpegl_vmaas_load_balancer_monitor" "tf_TCP_MONITOR" {
  lb_id       = data.hpegl_vmaas_load_balancer.tf_lb.id
  name        = "tf_TCP_MONITOR"
  description = "TCP_MONITOR create using tf"
  type        = "LBTcpMonitorProfile"
  tcp_monitor {
    fall_count    = 3
    interval      = 5
    monitor_port  = 80
    rise_count    = 3
    timeout       = 15
    request_body  = "request body data"
    response_data = "success"
  }
}
```

## Example usage for creating NSX-T Load balancer Monitor for UDP with all possible attributes

```terraform
# (C) Copyright 2022 Hewlett Packard Enterprise Development LP

# UDP Monitor
resource "hpegl_vmaas_load_balancer_monitor" "tf_UDP-MONITOR" {
  lb_id       = data.hpegl_vmaas_load_balancer.tf_lb.id
  name        = "tf_UDP-MONITOR"
  description = "UDP_MONITOR create using tf"
  type        = "LBUdpMonitorProfile"
  udp_monitor {
    fall_count    = 3
    interval      = 5
    monitor_port  = 80
    rise_count    = 3
    timeout       = 15
    request_body  = "request body data"
    response_data = "success"
  }
}
```

<!-- schema generated by tfplugindocs -->
## Schema

### Required

- `lb_id` (Number) Parent lb ID, lb_id can be obtained by using LB datasource/resource.
- `name` (String) Network loadbalancer Monitor name
- `type` (String) Provide the Supported values for monitor Type

### Optional

- `description` (String) Creating the Network Load balancer Monitor.
- `http_monitor` (Block List, Max: 1) HTTP Monitor configuration (see [below for nested schema](#nestedblock--http_monitor))
- `https_monitor` (Block List, Max: 1) Https Monitor configuration (see [below for nested schema](#nestedblock--https_monitor))
- `icmp_monitor` (Block List, Max: 1) Icmp Monitor configuration (see [below for nested schema](#nestedblock--icmp_monitor))
- `passive_monitor` (Block List, Max: 1) Passive Monitor configuration (see [below for nested schema](#nestedblock--passive_monitor))
- `tcp_monitor` (Block List, Max: 1) Tcp Monitor configuration (see [below for nested schema](#nestedblock--tcp_monitor))
- `udp_monitor` (Block List, Max: 1) Udp Monitor configuration (see [below for nested schema](#nestedblock--udp_monitor))

### Read-Only

- `id` (String) The ID of this resource.

<a id="nestedblock--http_monitor"></a>
### Nested Schema for `http_monitor`

Optional:

- `fall_count` (Number) Number of consecutive checks that must fail before marking it down.
- `interval` (Number) Set the number of times the server is tested before it is considered as DOWN
- `monitor_port` (Number) Set the value of the monitoring port.
- `request_body` (String) Enter the request body. Valid for the POST and PUT methods
- `request_method` (String) Select the method to detect the server status
- `request_url` (String) Enter the request URI for the method
- `request_version` (String) HTTP request version. Valid values are HTTP_VERSION_1_0 and HTTP_VERSION_1_1
- `response_data` (String) If the HTTP response body string and the HTTP health check response body match,then the server is considered as healthy
- `response_status_codes` (String) Enter the string that the monitor expects to match in the status line of HTTP response body.The response code is a comma-separated list
- `rise_count` (Number) Number of consecutive checks that must pass before marking it up
- `timeout` (Number) Set the number of times the server is tested before it is considered as DOWN


<a id="nestedblock--https_monitor"></a>
### Nested Schema for `https_monitor`

Optional:

- `fall_count` (Number) Number of consecutive checks that must fail before marking it down.
- `interval` (Number) Set the number of times the server is tested before it is considered as DOWN
- `monitor_port` (Number) Set the value of the monitoring port
- `request_body` (String) Enter the request body. Valid for the POST and PUT methods
- `request_method` (String) Select the method to detect the server status
- `request_url` (String) Enter the request URI for the method
- `request_version` (String) HTTP request version. Valid values are HTTP_VERSION_1_0 and HTTP_VERSION_1_1
- `response_data` (String) If the HTTP response body string and the HTTP health check response body match,then the server is considered as healthy
- `response_status_codes` (String) Enter the string that the monitor expects to match in the status line of HTTP response body.The response code is a comma-separated list
- `rise_count` (Number) Number of consecutive checks that must pass before marking it up
- `timeout` (Number) Set the number of times the server is tested before it is considered as DOWN


<a id="nestedblock--icmp_monitor"></a>
### Nested Schema for `icmp_monitor`

Optional:

- `data_length` (Number) Maximum size of the ICMP data packet
- `fall_count` (Number) Number of consecutive checks that must fail before marking it down
- `interval` (Number) Set the number of times the server is tested before it is considered as DOWN
- `monitor_port` (Number) Set the value of the monitoring port.
- `rise_count` (Number) Number of consecutive checks that must pass before marking it up
- `timeout` (Number) Set the number of times the server is tested before it is considered as DOWN


<a id="nestedblock--passive_monitor"></a>
### Nested Schema for `passive_monitor`

Optional:

- `max_fail` (Number) Set a value when the consecutive failures reach this value,the server is considered temporarily unavailable
- `timeout` (Number) Set the number of times the server is tested before it is considered as DOWN


<a id="nestedblock--tcp_monitor"></a>
### Nested Schema for `tcp_monitor`

Optional:

- `fall_count` (Number) Number of consecutive checks that must fail before marking it down.
- `interval` (Number) Set the number of times the server is tested before it is considered as DOWN
- `monitor_port` (Number) Set the value of the monitoring port.
- `request_body` (String) Enter the request body. Valid for the POST and PUT methods
- `response_data` (String) If the HTTP response body string and the HTTP health check response body matchthen the server is considered as healthy
- `rise_count` (Number) Number of consecutive checks that must pass before marking it up
- `timeout` (Number) Set the number of times the server is tested before it is considered as DOWN


<a id="nestedblock--udp_monitor"></a>
### Nested Schema for `udp_monitor`

Optional:

- `fall_count` (Number) Number of consecutive checks that must fail before marking it down.
- `interval` (Number) Set the number of times the server is tested before it is considered as DOWN
- `monitor_port` (Number) Set the value of the monitoring port.
- `request_body` (String) Enter the request body. Valid for the POST and PUT methods
- `response_data` (String) If the HTTP response body string and the HTTP health check response body match,then the server is considered as healthy
- `rise_count` (Number) Number of consecutive checks that must pass before marking it up
- `timeout` (Number) Set the number of times the server is tested before it is considered as DOWN