### PR TITLE
Documentation template for load balancer Pool

### DIFF
--- a/internal/resources/resource_lb_pools.go
+++ b/internal/resources/resource_lb_pools.go
@@ -68,13 +68,13 @@ func LoadBalancerPools() *schema.Resource {
 							Type:     schema.TypeInt,
 							Optional: true,
 							Description: "Passive Monitor ID, Get the `id` from " + DSLBMonitor +
-								"datasource to obtain the passive monitor ID",
+								" datasource to obtain the passive monitor ID",
 						},
 						"active_monitor_paths": {
 							Type:     schema.TypeInt,
 							Optional: true,
 							Description: "Active Monitor ID, Get the `id` from " + DSLBMonitor +
-								"datasource to obtain the active monitor ID",
+								" datasource to obtain the active monitor ID",
 						},
 						"tcp_multiplexing": {
 							Type:     schema.TypeBool,
@@ -140,12 +140,12 @@ func LoadBalancerPools() *schema.Resource {
 						"tag": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Description: "tag for Network Load balancer Profile",
+							Description: "tag for Network Load balancer Pool",
 						},
 						"scope": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Description: "scope for Network Load balancer Profile",
+							Description: "scope for Network Load balancer Pool",
 						},
 					},
 				},

--- a/internal/resources/resource_lb_pools.go
+++ b/internal/resources/resource_lb_pools.go
@@ -155,7 +155,7 @@ func LoadBalancerPools() *schema.Resource {
 		UpdateContext: loadbalancerPoolUpdateContext,
 		CreateContext: loadbalancerPoolCreateContext,
 		DeleteContext: loadbalancerPoolDeleteContext,
-		Description: `loadbalancer Pool resource facilitates creating,
+		Description: `loadbalancer Pool resource facilitates creating
 		and deleting NSX-T  Network Load Balancers.`,
 	}
 }

--- a/internal/resources/resource_lb_pools.go
+++ b/internal/resources/resource_lb_pools.go
@@ -67,13 +67,13 @@ func LoadBalancerPools() *schema.Resource {
 						"passive_monitor_path": {
 							Type:     schema.TypeInt,
 							Optional: true,
-							Description: "Passive Monitor ID, Get the `Id` from " + DSLBMonitor +
+							Description: "Passive Monitor ID, Get the `id` from " + DSLBMonitor +
 								"datasource to obtain the passive monitor ID",
 						},
 						"active_monitor_paths": {
 							Type:     schema.TypeInt,
 							Optional: true,
-							Description: "Active Monitor ID, Get the `Id` from " + DSLBMonitor +
+							Description: "Active Monitor ID, Get the `id` from " + DSLBMonitor +
 								"datasource to obtain the active monitor ID",
 						},
 						"tcp_multiplexing": {
@@ -155,8 +155,8 @@ func LoadBalancerPools() *schema.Resource {
 		UpdateContext: loadbalancerPoolUpdateContext,
 		CreateContext: loadbalancerPoolCreateContext,
 		DeleteContext: loadbalancerPoolDeleteContext,
-		Description: `loadbalancer Pool resource facilitates creating
-		and deleting NSX-T  Network Load Balancers.`,
+		Description: `loadbalancer Pool resource facilitates creating, updating
+		and deleting NSX-T Network Load Balancer Pools.`,
 	}
 }
 

--- a/internal/resources/resource_lb_pools.go
+++ b/internal/resources/resource_lb_pools.go
@@ -35,7 +35,7 @@ func LoadBalancerPools() *schema.Resource {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Default:     1,
-				Description: "minimum active members for the Network loadbalancer pool",
+				Description: "The minimum number of members for the pool to be considered active",
 			},
 			"algorithm": {
 				Type: schema.TypeString,
@@ -48,7 +48,8 @@ func LoadBalancerPools() *schema.Resource {
 				}, false),
 				Required:     true,
 				InputDefault: "ROUND_ROBIN",
-				Description:  "Provide the Supported values for pool algorithm",
+				Description: "Load balancing pool algorithm controls how the incoming connections" +
+					"are distributed among the members",
 			},
 			"config": {
 				Type:        schema.TypeList,
@@ -64,25 +65,30 @@ func LoadBalancerPools() *schema.Resource {
 							Description:      "Network Loadbalancer Supported values are `LBSnatAutoMap`,`LBSnatDisabled`, `LBSnatIpPool`",
 						},
 						"passive_monitor_path": {
-							Type:        schema.TypeInt,
-							Optional:    true,
-							Description: "passive_monitor_path for Network loadbalancer pool",
+							Type:     schema.TypeInt,
+							Optional: true,
+							Description: "Passive Monitor ID, Get the `Id` from " + DSLBMonitor +
+								"datasource to obtain the passive monitor ID",
 						},
 						"active_monitor_paths": {
-							Type:        schema.TypeInt,
-							Optional:    true,
-							Description: "active_monitor_paths for Network loadbalancer pool",
+							Type:     schema.TypeInt,
+							Optional: true,
+							Description: "Active Monitor ID, Get the `Id` from " + DSLBMonitor +
+								"datasource to obtain the active monitor ID",
 						},
 						"tcp_multiplexing": {
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Description: "tcp_multiplexing for Network loadbalancer pool",
+							Type:     schema.TypeBool,
+							Optional: true,
+							Description: "With TCP multiplexing, user can use the same TCP connection" +
+								"between a load balancer and the server for" +
+								"sending multiple client requests from different client TCP connections.",
 						},
 						"tcp_multiplexing_number": {
-							Type:        schema.TypeInt,
-							Optional:    true,
-							Default:     6,
-							Description: "tcp_multiplexing_number for Network loadbalancer pool",
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  6,
+							Description: "The maximum number of TCP connections per pool" +
+								"that are idly kept alive for sending future client requests",
 						},
 						"snat_ip_address": {
 							Type:        schema.TypeString,
@@ -96,24 +102,28 @@ func LoadBalancerPools() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"group": {
-										Type:        schema.TypeString,
-										Optional:    true,
-										Description: "name of member group",
+										Type:     schema.TypeString,
+										Optional: true,
+										Description: "Pool Member Groups path, get the `externalId` from " + DSPoolMemeberGroup +
+											"datasource to obtain the path",
 									},
 									"max_ip_list_size": {
-										Type:        schema.TypeInt,
-										Optional:    true,
-										Description: "max_ip_list_size of member group",
+										Type:     schema.TypeInt,
+										Optional: true,
+										Description: "It Should only be specified if `limit_ip_list_size` is set to true." +
+											"Limits the max number of pool members to the specified value",
 									},
 									"ip_revision_filter": {
 										Type:        schema.TypeString,
 										Optional:    true,
-										Description: "ipRevisionFilter of member group",
+										Description: "Ip version filter is used to filter `IPv4` addresses from the grouping object",
 									},
 									"port": {
-										Type:        schema.TypeInt,
-										Optional:    true,
-										Description: "port of member group",
+										Type:     schema.TypeInt,
+										Optional: true,
+										Description: "This is member port, The traffic which enter into VIP will get transfer" +
+											"to member groups based on the port specified." +
+											"Depends on the application running on the member VM",
 									},
 								},
 							},

--- a/internal/resources/resource_lb_pools.go
+++ b/internal/resources/resource_lb_pools.go
@@ -93,7 +93,7 @@ func LoadBalancerPools() *schema.Resource {
 						"snat_ip_address": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Description: "snat_ip_address for Network loadbalancer pool",
+							Description: "Address of the snat_ip for Network loadbalancer pool",
 						},
 						"member_group": {
 							Type:        schema.TypeList,

--- a/templates/resources/vmaas_load_balancer_pool.md.tmpl
+++ b/templates/resources/vmaas_load_balancer_pool.md.tmpl
@@ -1,0 +1,26 @@
+---
+layout: ""
+page_title: "hpegl_vmaas_load_balancer_pool Resource - vmaas-terraform-resources"
+subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+description: |-
+  {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+---
+
+# Resource hpegl_vmaas_load_balancer_pool
+
+-> Compatible version >= 5.4.6
+
+{{ .Description | trimspace }}
+`hpegl_vmaas_load_balancer_pool` resource supports NSX-T Load Balancer Pool creation.
+
+->  Load Balancer ID Data Source `hpegl_vmaas_load_balancer` is supported for Creating Pool.
+
+->  Load Balancer Monitor ID Data Source `hpegl_vmaas_load_balancer_monitor` is supported for Pool.
+
+->  Pool Member Groups path Data Source `hpegl_vmaas_lb_pool_member_group` is supported for Member Pool.
+
+## Example usage for creating NSX-T Load Balancer Pool with all possible attributes
+
+{{tffile "examples/resources/hpegl_vmaas_load_balancer_pool/resource.tf"}}
+
+{{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/vmaas_load_balancer_pool.md.tmpl
+++ b/templates/resources/vmaas_load_balancer_pool.md.tmpl
@@ -13,12 +13,6 @@ description: |-
 {{ .Description | trimspace }}
 `hpegl_vmaas_load_balancer_pool` resource supports NSX-T Load Balancer Pool creation.
 
-->  Load Balancer ID Data Source `hpegl_vmaas_load_balancer` is supported for Creating Pool.
-
-->  Load Balancer Monitor ID Data Source `hpegl_vmaas_load_balancer_monitor` is supported for Pool.
-
-->  Pool Member Groups path Data Source `hpegl_vmaas_lb_pool_member_group` is supported for Member Pool.
-
 ## Example usage for creating NSX-T Load Balancer Pool with all possible attributes
 
 {{tffile "examples/resources/hpegl_vmaas_load_balancer_pool/resource.tf"}}


### PR DESCRIPTION
---
layout: ""
page_title: "hpegl_vmaas_load_balancer_pool Resource - vmaas-terraform-resources"
subcategory: "vmaas"
description: |-
    loadbalancer Pool resource facilitates creating, updating
          and deleting NSX-T Network Load Balancer Pools.
---

# Resource hpegl_vmaas_load_balancer_pool

-> Compatible version >= 5.4.6

loadbalancer Pool resource facilitates creating, updating
		and deleting NSX-T Network Load Balancer Pools.
`hpegl_vmaas_load_balancer_pool` resource supports NSX-T Load Balancer Pool creation.

## Example usage for creating NSX-T Load Balancer Pool with all possible attributes

```terraform
# (C) Copyright 2022 Hewlett Packard Enterprise Development LP


resource "hpegl_vmaas_load_balancer_pool" "tf_POOL" {
  lb_id              = data.hpegl_vmaas_load_balancer.tf_lb.id
  name               = "tf_POOL"
  description        = "POOL created using tf"
  min_active_members = 1
  algorithm          = "WEIGHTED_ROUND_ROBIN"
  config {
    snat_translation_type   = "LBSnatAutoMap"
    active_monitor_paths    = data.hpegl_vmaas_load_balancer_monitor.tf_lb_active.id
    passive_monitor_path    = data.hpegl_vmaas_load_balancer_monitor.tf_lb_passive.id
    tcp_multiplexing        = false
    tcp_multiplexing_number = 6
    member_group {
      group              = data.hpegl_vmaas_lb_pool_member_group.tf_pool_group.external_id
      max_ip_list_size   = 1
      ip_revision_filter = "IPV4"
      port               = 80
    }
  }
  tags {
    tag   = "tag1"
    scope = "scope1"
  }
}
```

<!-- schema generated by tfplugindocs -->
## Schema

### Required

- `algorithm` (String) Load balancing pool algorithm controls how the incoming connectionsare distributed among the members
- `lb_id` (Number) Parent lb ID, lb_id can be obtained by using LB datasource/resource.
- `name` (String) Network loadbalancer pool name

### Optional

- `config` (Block List) pool Configuration (see [below for nested schema](#nestedblock--config))
- `description` (String) Creating the Network loadbalancer pool.
- `min_active_members` (Number) The minimum number of members for the pool to be considered active
- `tags` (Block List) tags Configuration (see [below for nested schema](#nestedblock--tags))

### Read-Only

- `id` (String) The ID of this resource.

<a id="nestedblock--config"></a>
### Nested Schema for `config`

Optional:

- `active_monitor_paths` (Number) Active Monitor ID, Get the `id` from hpegl_vmaas_load_balancer_monitor datasource to obtain the active monitor ID
- `member_group` (Block List) member group (see [below for nested schema](#nestedblock--config--member_group))
- `passive_monitor_path` (Number) Passive Monitor ID, Get the `id` from hpegl_vmaas_load_balancer_monitor datasource to obtain the passive monitor ID
- `snat_ip_address` (String) Address of the snat_ip for Network loadbalancer pool
- `snat_translation_type` (String) Network Loadbalancer Supported values are `LBSnatAutoMap`,`LBSnatDisabled`, `LBSnatIpPool`
- `tcp_multiplexing` (Boolean) With TCP multiplexing, user can use the same TCP connectionbetween a load balancer and the server forsending multiple client requests from different client TCP connections.
- `tcp_multiplexing_number` (Number) The maximum number of TCP connections per poolthat are idly kept alive for sending future client requests

<a id="nestedblock--config--member_group"></a>
### Nested Schema for `config.member_group`

Optional:

- `group` (String) Pool Member Groups path, get the `externalId` from hpegl_vmaas_lb_pool_member_groupdatasource to obtain the path
- `ip_revision_filter` (String) Ip version filter is used to filter `IPv4` addresses from the grouping object
- `max_ip_list_size` (Number) It Should only be specified if `limit_ip_list_size` is set to true.Limits the max number of pool members to the specified value
- `port` (Number) This is member port, The traffic which enter into VIP will get transferto member groups based on the port specified.Depends on the application running on the member VM



<a id="nestedblock--tags"></a>
### Nested Schema for `tags`

Optional:

- `scope` (String) scope for Network Load balancer Pool
- `tag` (String) tag for Network Load balancer Pool