### PR TITLE
Documentation template for load balancer Virtual Server

### DIFF
--- a/examples/resources/hpegl_vmaas_load_balancer_virtual_server/nsx_t_lb_virtual_server.tf
+++ b/examples/resources/hpegl_vmaas_load_balancer_virtual_server/nsx_t_lb_virtual_server.tf
@@ -6,11 +6,10 @@ resource "hpegl_vmaas_load_balancer_virtual_server" "tf_lb_virtual_server" {
   description  = "tf_virtual-server created by tf"
   vip_address     = "10.11.12.13"
   vip_port = "8080"
-  vip_host_name = "host VS"
   pool = data.hpegl_vmaas_load_balancer_pool.tf_pool.id
 
   type = "http"
-  http_application {
+  http_application_profile {
     application_profile = data.hpegl_vmaas_load_balancer_profile.tf_http_profile.id
   }
 

--- a/internal/resources/resource_lb_virtual_servers.go
+++ b/internal/resources/resource_lb_virtual_servers.go
@@ -111,7 +111,7 @@ func LoadBalancerVirtualServers() *schema.Resource {
 						"ssl_client_profile": {
 							Type:        schema.TypeInt,
 							Required:    true,
-							Description: "ssl_client_profile Id, Get the `id` from " + DSLBProfile + "datasource to obtain the ssl_client_profile Id",
+							Description: "ssl_client_profile Id, Get the `id` from " + DSLBProfile + " datasource to obtain the ssl_client_profile Id",
 						},
 					},
 				},

--- a/internal/resources/resource_lb_virtual_servers.go
+++ b/internal/resources/resource_lb_virtual_servers.go
@@ -46,8 +46,8 @@ func LoadBalancerVirtualServers() *schema.Resource {
 			"pool": {
 				Type:     schema.TypeInt,
 				Required: true,
-				Description: "It is recommended that you attach a pool to the Virtual Server to have a correct LB functionality." +
-					"ID of the loadBalncer Pool. Use " + DSLBPool + "datasource to obtain the id here",
+				Description: "Pool Id, Get the `id` from " + DSLBPool + " datasource to obtain the Pool Id, " +
+					"It is recommended that you attach a pool to the Virtual Server to have a correct LB functionality",
 			},
 			"type": {
 				Type: schema.TypeString,
@@ -77,8 +77,8 @@ func LoadBalancerVirtualServers() *schema.Resource {
 			"ssl_server_cert": {
 				Type:     schema.TypeInt,
 				Required: true,
-				Description: "SSLServerCert is needed only for https based load balancer" +
-					"ID of the ssl_server_cert. Use " + DSLBVirtualServerSslCert + "datasource to obtain the id  here",
+				Description: "ssl_server_cert Id, Get the `id` from " + DSLBVirtualServerSslCert + " datasource to obtain the ssl_server_cert Id, " +
+					"SSLServerCert is needed only for https based load balancer",
 			},
 			"ssl_server_config": {
 				Type:        schema.TypeList,
@@ -89,7 +89,7 @@ func LoadBalancerVirtualServers() *schema.Resource {
 						"ssl_server_profile": {
 							Type:        schema.TypeInt,
 							Required:    true,
-							Description: "ID of the ssl_server_profile. Use " + DSLBProfile + "datasource to obtain the id  here",
+							Description: "ssl_server_profile Id, Get the `id` from " + DSLBProfile + " datasource to obtain the ssl_server_profile Id",
 						},
 					},
 				},
@@ -97,8 +97,8 @@ func LoadBalancerVirtualServers() *schema.Resource {
 			"ssl_client_cert": {
 				Type:     schema.TypeInt,
 				Required: true,
-				Description: "SSLClientCert is needed only for https based load balancer." +
-					"ID of the ssl_client_cert. Use " + DSLBVirtualServerSslCert + "datasource to obtain the id  here",
+				Description: "ssl_client_cert Id, Get the `id` " + DSLBVirtualServerSslCert + " datasource to obtain the ssl_client_cert Id, " +
+					"SSLClientCert is needed only for https based load balancer",
 			},
 			"ssl_client_config": {
 				Type:        schema.TypeList,
@@ -109,7 +109,7 @@ func LoadBalancerVirtualServers() *schema.Resource {
 						"ssl_client_profile": {
 							Type:        schema.TypeInt,
 							Required:    true,
-							Description: "ID of the ssl_client_profile. Use " + DSLBProfile + "datasource to obtain the id  here",
+							Description: "ssl_client_profile Id, Get the `id` " + DSLBProfile + "datasource to obtain the ssl_client_profile Id",
 						},
 					},
 				},
@@ -120,8 +120,8 @@ func LoadBalancerVirtualServers() *schema.Resource {
 		CreateContext: loadbalancerVirtualServerCreateContext,
 		DeleteContext: loadbalancerVirtualServerDeleteContext,
 		CustomizeDiff: virtualServerCustomDiff,
-		Description: `loadbalancer Virtual Server resource facilitates creating
-		and deleting NSX-T  Network Load Balancers.`,
+		Description: `loadbalancer Virtual Server resource facilitates creating, updating
+		and deleting NSX-T Network Load Balancer Virtual Servers.`,
 	}
 }
 

--- a/internal/resources/resource_lb_virtual_servers.go
+++ b/internal/resources/resource_lb_virtual_servers.go
@@ -44,14 +44,10 @@ func LoadBalancerVirtualServers() *schema.Resource {
 				Description: "vip_port of network loadbalancer virtual server",
 			},
 			"pool": {
-				Type:        schema.TypeInt,
-				Required:    true,
-				Description: "pool of Network loadbalancer virtual server",
-			},
-			"vip_host_name": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "vip_host_name of Network loadbalancer virtual server",
+				Type:     schema.TypeInt,
+				Required: true,
+				Description: "It is recommended that you attach a pool to the Virtual Server to have a correct LB functionality." +
+					"ID of the loadBalncer Pool. Use " + DSLBPool + "datasource to obtain the id here",
 			},
 			"type": {
 				Type: schema.TypeString,
@@ -79,9 +75,10 @@ func LoadBalancerVirtualServers() *schema.Resource {
 			"cookie_persistence_profile":   schemas.CookiePersProfileSchema(),
 			"sourceip_persistence_profile": schemas.SourceipPersProfileSchema(),
 			"ssl_server_cert": {
-				Type:        schema.TypeInt,
-				Required:    true,
-				Description: "ID of the ssl_server_cert. Use " + DSLBVirtualServerSslCert + "datasource to obtain the id  here",
+				Type:     schema.TypeInt,
+				Required: true,
+				Description: "sslServerCert is needed only for https based load balancer" +
+					"ID of the ssl_server_cert. Use " + DSLBVirtualServerSslCert + "datasource to obtain the id  here",
 			},
 			"ssl_server_config": {
 				Type:        schema.TypeList,
@@ -98,9 +95,10 @@ func LoadBalancerVirtualServers() *schema.Resource {
 				},
 			},
 			"ssl_client_cert": {
-				Type:        schema.TypeInt,
-				Required:    true,
-				Description: "ID of the ssl_client_cert. Use " + DSLBVirtualServerSslCert + "datasource to obtain the id  here",
+				Type:     schema.TypeInt,
+				Required: true,
+				Description: "ssl_client_cert is needed only for https based load balancer." +
+					"ID of the ssl_client_cert. Use " + DSLBVirtualServerSslCert + "datasource to obtain the id  here",
 			},
 			"ssl_client_config": {
 				Type:        schema.TypeList,

--- a/internal/resources/resource_lb_virtual_servers.go
+++ b/internal/resources/resource_lb_virtual_servers.go
@@ -77,7 +77,8 @@ func LoadBalancerVirtualServers() *schema.Resource {
 			"ssl_server_cert": {
 				Type:     schema.TypeInt,
 				Required: true,
-				Description: "ssl_server_cert Id, Get the `id` from " + DSLBVirtualServerSslCert + " datasource to obtain the ssl_server_cert Id, " +
+				Description: "ssl_server_cert Id, Get the `id` from " + DSLBVirtualServerSslCert +
+					" datasource to obtain the ssl_server_cert Id, " +
 					"SSLServerCert is needed only for https based load balancer",
 			},
 			"ssl_server_config": {
@@ -109,9 +110,10 @@ func LoadBalancerVirtualServers() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"ssl_client_profile": {
-							Type:        schema.TypeInt,
-							Required:    true,
-							Description: "ssl_client_profile Id, Get the `id` from " + DSLBProfile + " datasource to obtain the ssl_client_profile Id",
+							Type:     schema.TypeInt,
+							Required: true,
+							Description: "ssl_client_profile Id, Get the `id` from " + DSLBProfile +
+								" datasource to obtain the ssl_client_profile Id",
 						},
 					},
 				},

--- a/internal/resources/resource_lb_virtual_servers.go
+++ b/internal/resources/resource_lb_virtual_servers.go
@@ -87,9 +87,10 @@ func LoadBalancerVirtualServers() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"ssl_server_profile": {
-							Type:        schema.TypeInt,
-							Required:    true,
-							Description: "ssl_server_profile Id, Get the `id` from " + DSLBProfile + " datasource to obtain the ssl_server_profile Id",
+							Type:     schema.TypeInt,
+							Required: true,
+							Description: "ssl_server_profile Id, Get the `id` from " + DSLBProfile +
+								" datasource to obtain the ssl_server_profile Id",
 						},
 					},
 				},
@@ -97,7 +98,8 @@ func LoadBalancerVirtualServers() *schema.Resource {
 			"ssl_client_cert": {
 				Type:     schema.TypeInt,
 				Required: true,
-				Description: "ssl_client_cert Id, Get the `id` " + DSLBVirtualServerSslCert + " datasource to obtain the ssl_client_cert Id, " +
+				Description: "ssl_client_cert Id, Get the `id` from " + DSLBVirtualServerSslCert +
+					" datasource to obtain the ssl_client_cert Id, " +
 					"SSLClientCert is needed only for https based load balancer",
 			},
 			"ssl_client_config": {
@@ -109,7 +111,7 @@ func LoadBalancerVirtualServers() *schema.Resource {
 						"ssl_client_profile": {
 							Type:        schema.TypeInt,
 							Required:    true,
-							Description: "ssl_client_profile Id, Get the `id` " + DSLBProfile + "datasource to obtain the ssl_client_profile Id",
+							Description: "ssl_client_profile Id, Get the `id` from " + DSLBProfile + "datasource to obtain the ssl_client_profile Id",
 						},
 					},
 				},

--- a/internal/resources/resource_lb_virtual_servers.go
+++ b/internal/resources/resource_lb_virtual_servers.go
@@ -120,7 +120,7 @@ func LoadBalancerVirtualServers() *schema.Resource {
 		CreateContext: loadbalancerVirtualServerCreateContext,
 		DeleteContext: loadbalancerVirtualServerDeleteContext,
 		CustomizeDiff: virtualServerCustomDiff,
-		Description: `loadbalancer Virtual Server resource facilitates creating,
+		Description: `loadbalancer Virtual Server resource facilitates creating
 		and deleting NSX-T  Network Load Balancers.`,
 	}
 }

--- a/internal/resources/resource_lb_virtual_servers.go
+++ b/internal/resources/resource_lb_virtual_servers.go
@@ -26,22 +26,22 @@ func LoadBalancerVirtualServers() *schema.Resource {
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "vip_name of Network loadbalancer virtual server name",
+				Description: "Name of Network loadbalancer virtual server name",
 			},
 			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "description of Network loadbalancer virtual server",
+				Description: "Description of Network loadbalancer virtual server",
 			},
 			"vip_address": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "vip_address of Network loadbalancer virtual server",
+				Description: "Vip_address of Network loadbalancer virtual server",
 			},
 			"vip_port": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "vip_port of network loadbalancer virtual server",
+				Description: "Vip_port of network loadbalancer virtual server",
 			},
 			"pool": {
 				Type:     schema.TypeInt,
@@ -58,7 +58,7 @@ func LoadBalancerVirtualServers() *schema.Resource {
 				}, false),
 				Required:     true,
 				InputDefault: "http",
-				Description:  "vip protocol of Network loadbalancer virtual server",
+				Description:  "Vip protocol of Network loadbalancer virtual server",
 			},
 			"tcp_application_profile":  schemas.TCPAppProfileSchema(),
 			"udp_application_profile":  schemas.UDPAppProfileSchema(),
@@ -70,14 +70,14 @@ func LoadBalancerVirtualServers() *schema.Resource {
 					"COOKIE",
 				}, false),
 				Optional:    true,
-				Description: "persistence type for Network loadbalancer virtual server",
+				Description: "Persistence type for Network loadbalancer virtual server",
 			},
 			"cookie_persistence_profile":   schemas.CookiePersProfileSchema(),
 			"sourceip_persistence_profile": schemas.SourceipPersProfileSchema(),
 			"ssl_server_cert": {
 				Type:     schema.TypeInt,
 				Required: true,
-				Description: "sslServerCert is needed only for https based load balancer" +
+				Description: "SSLServerCert is needed only for https based load balancer" +
 					"ID of the ssl_server_cert. Use " + DSLBVirtualServerSslCert + "datasource to obtain the id  here",
 			},
 			"ssl_server_config": {
@@ -97,7 +97,7 @@ func LoadBalancerVirtualServers() *schema.Resource {
 			"ssl_client_cert": {
 				Type:     schema.TypeInt,
 				Required: true,
-				Description: "ssl_client_cert is needed only for https based load balancer." +
+				Description: "SSLClientCert is needed only for https based load balancer." +
 					"ID of the ssl_client_cert. Use " + DSLBVirtualServerSslCert + "datasource to obtain the id  here",
 			},
 			"ssl_client_config": {

--- a/internal/resources/schemas/lb_vs_schemas.go
+++ b/internal/resources/schemas/lb_vs_schemas.go
@@ -19,9 +19,10 @@ func TCPAppProfileSchema() *schema.Schema {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"application_profile": {
-					Type:        schema.TypeInt,
-					Required:    true,
-					Description: "TCP application_profile Id, Get the `id` from " + DSLBProfile + " datasource to obtain the TCP application_profile Id",
+					Type:     schema.TypeInt,
+					Required: true,
+					Description: "TCP application_profile Id, Get the `id` from " + DSLBProfile +
+						" datasource to obtain the TCP application_profile Id",
 				},
 			},
 		},
@@ -39,9 +40,10 @@ func UDPAppProfileSchema() *schema.Schema {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"application_profile": {
-					Type:        schema.TypeInt,
-					Required:    true,
-					Description: "UDP application_profile Id, Get the `id` from " + DSLBProfile + " datasource to obtain the UDP application_profile Id",
+					Type:     schema.TypeInt,
+					Required: true,
+					Description: "UDP application_profile Id, Get the `id` from " + DSLBProfile +
+						" datasource to obtain the UDP application_profile Id",
 				},
 			},
 		},
@@ -59,9 +61,10 @@ func HTTPAppProfileSchema() *schema.Schema {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"application_profile": {
-					Type:        schema.TypeInt,
-					Required:    true,
-					Description: "HTTP application_profile Id, Get the `id` from " + DSLBProfile + " datasource to obtain the HTTP application_profile Id",
+					Type:     schema.TypeInt,
+					Required: true,
+					Description: "HTTP application_profile Id, Get the `id` from " + DSLBProfile +
+						" datasource to obtain the HTTP application_profile Id",
 				},
 			},
 		},
@@ -79,9 +82,10 @@ func CookiePersProfileSchema() *schema.Schema {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"persistence_profile": {
-					Type:        schema.TypeInt,
-					Required:    true,
-					Description: "COOKIE persistence_profile Id, Get the `id` from " + DSLBProfile + " datasource to obtain the COOKIE persistence_profile Id",
+					Type:     schema.TypeInt,
+					Required: true,
+					Description: "COOKIE persistence_profile Id, Get the `id` from " + DSLBProfile +
+						" datasource to obtain the COOKIE persistence_profile Id",
 				},
 			},
 		},
@@ -99,9 +103,10 @@ func SourceipPersProfileSchema() *schema.Schema {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"persistence_profile": {
-					Type:        schema.TypeInt,
-					Required:    true,
-					Description: "SOURCEIP persistence_profile Id, Get the `id` from " + DSLBProfile + " datasource to obtain the SOURCEIP persistence_profile Id",
+					Type:     schema.TypeInt,
+					Required: true,
+					Description: "SOURCEIP persistence_profile Id, Get the `id` from " + DSLBProfile +
+						" datasource to obtain the SOURCEIP persistence_profile Id",
 				},
 			},
 		},

--- a/internal/resources/schemas/lb_vs_schemas.go
+++ b/internal/resources/schemas/lb_vs_schemas.go
@@ -21,7 +21,7 @@ func TCPAppProfileSchema() *schema.Schema {
 				"application_profile": {
 					Type:        schema.TypeInt,
 					Required:    true,
-					Description: "ID of the TCP application_profile. Use " + DSLBProfile + "datasource to obtain the id here",
+					Description: "TCP application_profile Id, Get the `id` from " + DSLBProfile + " datasource to obtain the TCP application_profile Id",
 				},
 			},
 		},
@@ -41,7 +41,7 @@ func UDPAppProfileSchema() *schema.Schema {
 				"application_profile": {
 					Type:        schema.TypeInt,
 					Required:    true,
-					Description: "ID of the UDP application_profile. Use " + DSLBProfile + "datasource to obtain the id here",
+					Description: "UDP application_profile Id, Get the `id` from " + DSLBProfile + " datasource to obtain the UDP application_profile Id",
 				},
 			},
 		},
@@ -61,7 +61,7 @@ func HTTPAppProfileSchema() *schema.Schema {
 				"application_profile": {
 					Type:        schema.TypeInt,
 					Required:    true,
-					Description: "ID of the HTTP application_profile. Use " + DSLBProfile + "datasource to obtain the id here",
+					Description: "HTTP application_profile Id, Get the `id` from " + DSLBProfile + " datasource to obtain the HTTP application_profile Id",
 				},
 			},
 		},
@@ -81,7 +81,7 @@ func CookiePersProfileSchema() *schema.Schema {
 				"persistence_profile": {
 					Type:        schema.TypeInt,
 					Required:    true,
-					Description: "ID of the COOKIE persistence_profile. Use " + DSLBProfile + "datasource to obtain the id here",
+					Description: "COOKIE persistence_profile Id, Get the `id` from " + DSLBProfile + " datasource to obtain the COOKIE persistence_profile Id",
 				},
 			},
 		},
@@ -101,7 +101,7 @@ func SourceipPersProfileSchema() *schema.Schema {
 				"persistence_profile": {
 					Type:        schema.TypeInt,
 					Required:    true,
-					Description: "ID of the SOURCEIP persistence_profile. Use " + DSLBProfile + "datasource to obtain the id here",
+					Description: "SOURCEIP persistence_profile Id, Get the `id` from " + DSLBProfile + " datasource to obtain the SOURCEIP persistence_profile Id",
 				},
 			},
 		},

--- a/templates/resources/vmaas_load_balancer_virtual_server.md.tmpl
+++ b/templates/resources/vmaas_load_balancer_virtual_server.md.tmpl
@@ -1,0 +1,28 @@
+---
+layout: ""
+page_title: "hpegl_vmaas_load_balancer_virtual_server Resource - vmaas-terraform-resources"
+subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+description: |-
+  {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+---
+
+# Resource hpegl_vmaas_load_balancer_virtual_server
+
+-> Compatible version >= 5.4.6
+
+{{ .Description | trimspace }}
+`hpegl_vmaas_load_balancer_virtual_server` resource supports NSX-T Load Balancer Virtual Server creation.
+
+->  Load Balancer ID Data Source `hpegl_vmaas_load_balancer` is supported for Creating Virtual Server.
+
+->  Load Balancer Profile ID Data Source `hpegl_vmaas_load_balancer_profile` is supported for Virtual Server.
+
+->  Load Balancer Pool ID Data Source `hpegl_vmaas_load_balancer_pool` is supported for Virtual Server.
+
+->  SSL Certificate ID Data Source `hpegl_vmaas_load_balancer_virtual_server_ssl_cert` is supported for Virtual Server.
+
+## Example usage for creating NSX-T Load Balancer Virtual Server with all possible attributes
+
+{{tffile "examples/resources/hpegl_vmaas_load_balancer_virtual_server/nsx_t_lb_virtual_server.tf"}}
+
+{{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/vmaas_load_balancer_virtual_server.md.tmpl
+++ b/templates/resources/vmaas_load_balancer_virtual_server.md.tmpl
@@ -13,14 +13,6 @@ description: |-
 {{ .Description | trimspace }}
 `hpegl_vmaas_load_balancer_virtual_server` resource supports NSX-T Load Balancer Virtual Server creation.
 
-->  Load Balancer ID Data Source `hpegl_vmaas_load_balancer` is supported for Creating Virtual Server.
-
-->  Load Balancer Profile ID Data Source `hpegl_vmaas_load_balancer_profile` is supported for Virtual Server.
-
-->  Load Balancer Pool ID Data Source `hpegl_vmaas_load_balancer_pool` is supported for Virtual Server.
-
-->  SSL Certificate ID Data Source `hpegl_vmaas_load_balancer_virtual_server_ssl_cert` is supported for Virtual Server.
-
 ## Example usage for creating NSX-T Load Balancer Virtual Server with all possible attributes
 
 {{tffile "examples/resources/hpegl_vmaas_load_balancer_virtual_server/nsx_t_lb_virtual_server.tf"}}


### PR DESCRIPTION
---
layout: ""
page_title: "hpegl_vmaas_load_balancer_virtual_server Resource - vmaas-terraform-resources"
subcategory: "vmaas"
description: |-
    loadbalancer Virtual Server resource facilitates creating, updating
          and deleting NSX-T Network Load Balancer Virtual Servers.
---

# Resource hpegl_vmaas_load_balancer_virtual_server

-> Compatible version >= 5.4.6

loadbalancer Virtual Server resource facilitates creating, updating
		and deleting NSX-T Network Load Balancer Virtual Servers.
`hpegl_vmaas_load_balancer_virtual_server` resource supports NSX-T Load Balancer Virtual Server creation.

## Example usage for creating NSX-T Load Balancer Virtual Server with all possible attributes

```terraform
# (C) Copyright 2022 Hewlett Packard Enterprise Development LP

resource "hpegl_vmaas_load_balancer_virtual_server" "tf_lb_virtual_server" {
  lb_id       = data.hpegl_vmaas_load_balancer.tf_lb.id
  name        = "tf_virtual-server"
  description = "tf_virtual-server created by tf"
  vip_address = "10.11.12.13"
  vip_port    = "8080"
  pool        = data.hpegl_vmaas_load_balancer_pool.tf_pool.id

  type = "http"
  http_application_profile {
    application_profile = data.hpegl_vmaas_load_balancer_profile.tf_http_profile.id
  }

  persistence = "COOKIE"
  cookie_persistence_profile {
    persistence_profile = data.hpegl_vmaas_load_balancer_profile.tf_cookie_profile.id
  }

  ssl_server_cert = data.hpegl_vmaas_load_balancer_virtual_server_ssl_cert.tf_ssl_cert.id
  ssl_server_config {
    ssl_server_profile = data.hpegl_vmaas_load_balancer_profile.tf_ssl_server_profile.id
  }

  ssl_client_cert = data.hpegl_vmaas_load_balancer_virtual_server_ssl_cert.tf_ssl_cert.id
  ssl_client_config {
    ssl_client_profile = data.hpegl_vmaas_load_balancer_profile.tf_ssl_client_profile.id
  }

}
```

<!-- schema generated by tfplugindocs -->
## Schema

### Required

- `lb_id` (Number) Parent lb ID, lb_id can be obtained by using LB datasource/resource.
- `name` (String) Name of Network loadbalancer virtual server name
- `pool` (Number) Pool Id, Get the `id` from hpegl_vmaas_load_balancer_pool datasource to obtain the Pool Id, It is recommended that you attach a pool to the Virtual Server to have a correct LB functionality
- `ssl_client_cert` (Number) ssl_client_cert Id, Get the `id` from hpegl_vmaas_load_balancer_virtual_server_ssl_cert datasource to obtain the ssl_client_cert Id, SSLClientCert is needed only for https based load balancer
- `ssl_server_cert` (Number) ssl_server_cert Id, Get the `id` from hpegl_vmaas_load_balancer_virtual_server_ssl_cert datasource to obtain the ssl_server_cert Id, SSLServerCert is needed only for https based load balancer
- `type` (String) Vip protocol of Network loadbalancer virtual server
- `vip_address` (String) Vip_address of Network loadbalancer virtual server
- `vip_port` (String) Vip_port of network loadbalancer virtual server

### Optional

- `cookie_persistence_profile` (Block List, Max: 1) Cookie profile configuration (see [below for nested schema](#nestedblock--cookie_persistence_profile))
- `description` (String) Description of Network loadbalancer virtual server
- `http_application_profile` (Block List, Max: 1) HTTP Profile configuration (see [below for nested schema](#nestedblock--http_application_profile))
- `persistence` (String) Persistence type for Network loadbalancer virtual server
- `sourceip_persistence_profile` (Block List, Max: 1) HTTP profile configuration (see [below for nested schema](#nestedblock--sourceip_persistence_profile))
- `ssl_client_config` (Block List) virtual server Configuration (see [below for nested schema](#nestedblock--ssl_client_config))
- `ssl_server_config` (Block List) virtual server Configuration (see [below for nested schema](#nestedblock--ssl_server_config))
- `tcp_application_profile` (Block List, Max: 1) TCP Profile configuration (see [below for nested schema](#nestedblock--tcp_application_profile))
- `udp_application_profile` (Block List, Max: 1) UDP profile configuration (see [below for nested schema](#nestedblock--udp_application_profile))

### Read-Only

- `id` (String) The ID of this resource.

<a id="nestedblock--cookie_persistence_profile"></a>
### Nested Schema for `cookie_persistence_profile`

Required:

- `persistence_profile` (Number) COOKIE persistence_profile Id, Get the `id` from hpegl_vmaas_load_balancer_profile datasource to obtain the COOKIE persistence_profile Id


<a id="nestedblock--http_application_profile"></a>
### Nested Schema for `http_application_profile`

Required:

- `application_profile` (Number) HTTP application_profile Id, Get the `id` from hpegl_vmaas_load_balancer_profile datasource to obtain the HTTP application_profile Id


<a id="nestedblock--sourceip_persistence_profile"></a>
### Nested Schema for `sourceip_persistence_profile`

Required:

- `persistence_profile` (Number) SOURCEIP persistence_profile Id, Get the `id` from hpegl_vmaas_load_balancer_profile datasource to obtain the SOURCEIP persistence_profile Id


<a id="nestedblock--ssl_client_config"></a>
### Nested Schema for `ssl_client_config`

Required:

- `ssl_client_profile` (Number) ssl_client_profile Id, Get the `id` from hpegl_vmaas_load_balancer_profile datasource to obtain the ssl_client_profile Id


<a id="nestedblock--ssl_server_config"></a>
### Nested Schema for `ssl_server_config`

Required:

- `ssl_server_profile` (Number) ssl_server_profile Id, Get the `id` from hpegl_vmaas_load_balancer_profile datasource to obtain the ssl_server_profile Id


<a id="nestedblock--tcp_application_profile"></a>
### Nested Schema for `tcp_application_profile`

Required:

- `application_profile` (Number) TCP application_profile Id, Get the `id` from hpegl_vmaas_load_balancer_profile datasource to obtain the TCP application_profile Id


<a id="nestedblock--udp_application_profile"></a>
### Nested Schema for `udp_application_profile`

Required:

- `application_profile` (Number) UDP application_profile Id, Get the `id` from hpegl_vmaas_load_balancer_profile datasource to obtain the UDP application_profile Id