### PR TITLE
6.2.4 NSX name fix

### DIFF
--- a/acc-testcases/resources/load_balancer.yaml
+++ b/acc-testcases/resources/load_balancer.yaml
@@ -1,0 +1,18 @@
+vars:
+  name: "tf_loadbalancer_%rand_int"
+acc:
+- config: |
+    name = "$(name)"
+    description  = "Loadbalancer created using tf"
+    enabled      =  true
+    group_access {
+      all = true
+    }
+    config {
+      admin_state = true
+      size = "SMALL"
+      log_level = "INFO"
+      tier1_gateways  = "/infra/tier-1s/d3561ba7-01c9-4fa7-a7c5-bac401fd8f75"
+    }
+  validations:
+    json.loadBalancer.config.tier1: "/infra/tier-1s/d3561ba7-01c9-4fa7-a7c5-bac401fd8f75"

--- a/internal/acceptance_test/data_source_edge_cluster_test.go
+++ b/internal/acceptance_test/data_source_edge_cluster_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	api_client "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/client"
+	"github.com/HewlettPackard/hpegl-vmaas-terraform-resources/internal/utils"
 	"github.com/HewlettPackard/hpegl-vmaas-terraform-resources/pkg/atf"
 )
 
@@ -30,8 +31,17 @@ func TestAccDataSourceNetworkEdgeCluster(t *testing.T) {
 			if len(ServerResp.NetworkServices) == 0 {
 				return nil, err
 			}
+			cmpVersion, err := utils.GetCmpVersion(iClient.Client)
+			if err != nil {
+				return nil, err
+			}
+			nsxVar := "NSX-T"
+			if v, _ := utils.ParseVersion("6.2.4"); v <= cmpVersion {
+				// from 6.2.4 onwards the display name of NSX-T has been change to NSX
+				nsxVar = "NSX"
+			}
 			for i, n := range ServerResp.NetworkServices {
-				if n.TypeName == "NSX-T" {
+				if n.TypeName == nsxVar {
 					serverID = ServerResp.NetworkServices[i].ID
 
 					break

--- a/internal/cmp/constants.go
+++ b/internal/cmp/constants.go
@@ -6,7 +6,9 @@ import "time"
 
 const (
 	vmware        = "vmware"
+	nsxSegment    = "NSX Segment"
 	nsxtSegment   = "NSX-T Segment"
+	nsx           = "NSX"
 	nsxt          = "NSX-T"
 	errExactMatch = "error, could not find the %s with the specified name. Please verify the name and try again"
 	successErr    = "got success = 'false while %s"
@@ -20,7 +22,9 @@ const (
 	// retry related constants
 	maxTimeout = time.Hour * 2
 	// router consts
+	nsxTier0GatewayType          = "NSX Tier-0 Gateway"
 	tier0GatewayType             = "NSX-T Tier-0 Gateway"
+	nsxTier1GatewayType          = "NSX Tier-1 Gateway"
 	tier1GatewayType             = "NSX-T Tier-1 Gateway"
 	routerFirewallExternalPolicy = "GatewayPolicy"
 	syncedTypeValue              = "Synced"

--- a/internal/cmp/data_source_lb_pool_member_group.go
+++ b/internal/cmp/data_source_lb_pool_member_group.go
@@ -34,7 +34,15 @@ func (n *poolMemberGroupds) Read(ctx context.Context, d *utils.Data, meta interf
 	if err := d.Error(); err != nil {
 		return err
 	}
-
+	cmpVersion, err := utils.GetCmpVersion(n.rClient.Client)
+	if err != nil {
+		return err
+	}
+	nsxVar := nsxt
+	if v, _ := utils.ParseVersion("6.2.4"); v <= cmpVersion {
+		// from 6.2.4 onwards the display name of NSX-T has been change to NSX
+		nsxVar = nsx
+	}
 	setMeta(meta, n.rClient.Client)
 	// Get network server ID for nsx-t
 	serverResp, err := n.rClient.GetNetworkServices(ctx, nil)
@@ -44,7 +52,7 @@ func (n *poolMemberGroupds) Read(ctx context.Context, d *utils.Data, meta interf
 
 	var serverID int
 	for i, n := range serverResp.NetworkServices {
-		if n.TypeName == nsxt {
+		if n.TypeName == nsxVar {
 			serverID = serverResp.NetworkServices[i].ID
 
 			break

--- a/internal/cmp/dhcp_server.go
+++ b/internal/cmp/dhcp_server.go
@@ -122,6 +122,15 @@ func (dhcp *dhcpServer) Delete(ctx context.Context, d *utils.Data, meta interfac
 func (dhcp *dhcpServer) dhcpServerAlignRequest(ctx context.Context, meta interface{},
 	createReq *models.CreateNetworkDhcpServerRequest) error {
 	// Get network service ID
+	cmpVersion, err := utils.GetCmpVersion(dhcp.rClient.Client)
+	if err != nil {
+		return err
+	}
+	nsxVar := nsxt
+	if v, _ := utils.ParseVersion("6.2.4"); v <= cmpVersion {
+		// from 6.2.4 onwards the display name of NSX-T has been change to NSX
+		nsxVar = nsx
+	}
 	setMeta(meta, dhcp.rClient.Client)
 	nsRetry := utils.CustomRetry{}
 	nsRetry.RetryParallel(ctx, meta, func(ctx context.Context) (interface{}, error) {
@@ -136,7 +145,7 @@ func (dhcp *dhcpServer) dhcpServerAlignRequest(ctx context.Context, meta interfa
 	networkService := nsResp.(models.GetNetworkServicesResp)
 
 	for i, n := range networkService.NetworkServices {
-		if n.TypeName == nsxt {
+		if n.TypeName == nsxVar {
 			createReq.NetworkDhcpServer.ID = networkService.NetworkServices[i].ID
 
 			break

--- a/internal/cmp/dhcp_server_datasource.go
+++ b/internal/cmp/dhcp_server_datasource.go
@@ -34,7 +34,15 @@ func (n *dhcpServerds) Read(ctx context.Context, d *utils.Data, meta interface{}
 	if err := d.Error(); err != nil {
 		return err
 	}
-
+	cmpVersion, err := utils.GetCmpVersion(n.rClient.Client)
+	if err != nil {
+		return err
+	}
+	nsxVar := nsxt
+	if v, _ := utils.ParseVersion("6.2.4"); v <= cmpVersion {
+		// from 6.2.4 onwards the display name of NSX-T has been change to NSX
+		nsxVar = nsx
+	}
 	setMeta(meta, n.rClient.Client)
 	// Get network server ID for nsx-t
 	serverResp, err := n.rClient.GetNetworkServices(ctx, nil)
@@ -44,7 +52,7 @@ func (n *dhcpServerds) Read(ctx context.Context, d *utils.Data, meta interface{}
 
 	var serverID int
 	for i, n := range serverResp.NetworkServices {
-		if n.TypeName == nsxt {
+		if n.TypeName == nsxVar {
 			serverID = serverResp.NetworkServices[i].ID
 
 			break

--- a/internal/cmp/edge_cluster.go
+++ b/internal/cmp/edge_cluster.go
@@ -24,6 +24,15 @@ func newEdgeCluster(tClient *client.RouterAPIService) *edgeCluster {
 }
 
 func (r *edgeCluster) Read(ctx context.Context, d *utils.Data, meta interface{}) error {
+	cmpVersion, err := utils.GetCmpVersion(r.tClient.Client)
+	if err != nil {
+		return err
+	}
+	nsxVar := nsxt
+	if v, _ := utils.ParseVersion("6.2.4"); v <= cmpVersion {
+		// from 6.2.4 onwards the display name of NSX-T has been change to NSX
+		nsxVar = nsx
+	}
 	setMeta(meta, r.tClient.Client)
 	log.Printf("[INFO] Get Edge Cluster")
 	var tfEdgeCluster models.NetworkEdgeClusters
@@ -39,7 +48,7 @@ func (r *edgeCluster) Read(ctx context.Context, d *utils.Data, meta interface{})
 
 	var serverID int
 	for i, n := range serverResp.NetworkServices {
-		if n.TypeName == nsxt {
+		if n.TypeName == nsxVar {
 			serverID = serverResp.NetworkServices[i].ID
 
 			break

--- a/internal/cmp/transport_zone.go
+++ b/internal/cmp/transport_zone.go
@@ -23,6 +23,15 @@ func newTransportZone(tClient *client.RouterAPIService) *transportZone {
 }
 
 func (r *transportZone) Read(ctx context.Context, d *utils.Data, meta interface{}) error {
+	cmpVersion, err := utils.GetCmpVersion(r.tClient.Client)
+	if err != nil {
+		return err
+	}
+	nsxVar := nsxt
+	if v, _ := utils.ParseVersion("6.2.4"); v <= cmpVersion {
+		// from 6.2.4 onwards the display name of NSX-T has been change to NSX
+		nsxVar = nsx
+	}
 	setMeta(meta, r.tClient.Client)
 	var tfScope models.NetworkScope
 	if err := tftags.Get(d, &tfScope); err != nil {
@@ -37,7 +46,7 @@ func (r *transportZone) Read(ctx context.Context, d *utils.Data, meta interface{
 
 	var serverID int
 	for i, n := range serverResp.NetworkServices {
-		if n.TypeName == nsxt {
+		if n.TypeName == nsxVar {
 			serverID = serverResp.NetworkServices[i].ID
 
 			break

--- a/internal/utils/cmp_version.go
+++ b/internal/utils/cmp_version.go
@@ -1,0 +1,44 @@
+// (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+
+package utils
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/client"
+)
+
+func ParseVersion(version string) (int, error) {
+	if version == "" {
+		return 0, nil
+	}
+
+	versionSplit := strings.Split(version, ".")
+
+	mul := 10000
+	sum := 0
+	for _, v := range versionSplit {
+		vInt, err := strconv.Atoi(v)
+		if err != nil {
+			return 0, err
+		}
+		sum += mul * vInt
+		mul /= 100
+	}
+
+	return sum, nil
+}
+
+func GetCmpVersion(apiClient client.APIClientHandler) (int, error) {
+	c := client.CmpStatus{
+		Client: apiClient,
+	}
+
+	cmpVersion, err := c.GetCmpVersion(context.Background())
+	if err != nil {
+		return 0, err
+	}
+	return ParseVersion(cmpVersion.Appliance.BuildVersion)
+}


### PR DESCRIPTION
From Morpheus 6.2.x onwards Morpheus will have a common display name for all the NSX* resources.