### PR TITLE
Include IaC testing for cicd

### DIFF
--- a/.github/parse_logs.py
+++ b/.github/parse_logs.py
@@ -8,21 +8,25 @@ import sys
 def main(args):
     n = len(args)
     if n != 2:
-        print("Pass the log directory")
+        print("Pass the log directory or txt file path")
         return 1
     log_path = args[1]
     file_content = ''
-    for x in os.listdir(log_path):
-        if x.endswith(".txt"):            
-            with open(os.path.join(log_path, x)) as f:
-                file_content += (f.read())
-    test_count = file_content.count('RUN')
+    if log_path.endswith(".txt"):
+        with open(log_path) as f:
+            file_content += (f.read())
+    else:
+        for x in os.listdir(log_path):
+            if x.endswith(".txt"):            
+                with open(os.path.join(log_path, x)) as f:
+                    file_content += (f.read())
+    test_count = file_content.count('RUN') - file_content.count('SKIP:')
     pass_count = file_content.count('PASS:')
     fail_count = file_content.count('FAIL:')
     print(
-        f"\nTestcases Ran: {test_count}; "
-        f"Testcases Passed: {pass_count}; "
-        f"Testcases Failed: {fail_count}; ")
+        f"\nTestcases Ran: {test_count}; \n"
+        f"Testcases Passed: {pass_count}; \n"
+        f"Testcases Failed: {fail_count}; \n")
     return 0
 
 if __name__ == "__main__":

--- a/.github/parse_logs.py
+++ b/.github/parse_logs.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+
+import os
+import sys
+
+
+def main(args):
+    n = len(args)
+    print(args)
+    if n != 2:
+        print("Pass the log directory")
+        return 1
+    log_path = args[1]
+    file_content = ''
+    for x in os.listdir(log_path):
+        if x.endswith(".txt"):            
+            with open(os.path.join(log_path, x)) as f:
+                file_content += (f.read())
+    test_count = file_content.count('RUN')
+    pass_count = file_content.count('PASS:')
+    fail_count = file_content.count('FAIL:')
+    print(
+        f"\nTestcases Ran: {test_count}\n"
+        f"Testcases Passed: {pass_count}\n"
+        f"Testcases Failed: {fail_count}\n")
+    return 0
+
+if __name__ == "__main__":
+    exit(main(sys.argv))

--- a/.github/parse_logs.py
+++ b/.github/parse_logs.py
@@ -7,7 +7,6 @@ import sys
 
 def main(args):
     n = len(args)
-    print(args)
     if n != 2:
         print("Pass the log directory")
         return 1
@@ -21,9 +20,9 @@ def main(args):
     pass_count = file_content.count('PASS:')
     fail_count = file_content.count('FAIL:')
     print(
-        f"\nTestcases Ran: {test_count}\n"
-        f"Testcases Passed: {pass_count}\n"
-        f"Testcases Failed: {fail_count}\n")
+        f"\nTestcases Ran: {test_count}; "
+        f"Testcases Passed: {pass_count}; "
+        f"Testcases Failed: {fail_count}; ")
     return 0
 
 if __name__ == "__main__":

--- a/.github/workflows/acc.yml
+++ b/.github/workflows/acc.yml
@@ -7,46 +7,33 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
       inputs:
-        logLevel:
-          description: 'Log level'     
+        test_case:
+          description: 'Enter testcases sperated by space. Leave empty for all'     
+          required: false
+          default: ''
+          type: string
+        test_description:
+          description: 'Enter description for the test'     
           required: true
-          default: 'warning'
-        tags:
-          description: 'Test scenario tags'
+          default: 'Check all Terraform Testcases'
+          type: string
+
   release:
     types: [published]
-env:
-  HPEGL_IAM_SERVICE_URL: ${{ secrets.HPEGL_IAM_SERVICE_URL }}
-  HPEGL_TENANT_ID: ${{ secrets.HPEGL_TENANT_ID }}
-  HPEGL_USER_SECRET: ${{ secrets.HPEGL_USER_SECRET }}
-  HPEGL_USER_ID: ${{ secrets.HPEGL_USER_ID }}
-  HPEGL_VMAAS_API_URL: ${{ secrets.HPEGL_VMAAS_API_URL }}
-  HPEGL_VMAAS_LOCATION: ${{ secrets.HPEGL_VMAAS_LOCATION }}
-  HPEGL_VMAAS_SPACE_NAME: ${{ secrets.HPEGL_VMAAS_SPACE_NAME}}
-  TF_ACC: ${{ secrets.TF_ACC }}
+
 jobs:
-  acc:
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        go: [ '1.17' ]
-    name: Acceptance Tests
-    steps:
-      - name: Checkout workspace
-        uses: actions/checkout@v3
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.17
-      - name: Install dependencies
-        run: |
-          sudo apt-get install -y wget jq
-          wget https://releases.hashicorp.com/terraform/1.0.0/terraform_1.0.0_linux_amd64.zip
-          sudo unzip -fo terraform_1.0.0_linux_amd64.zip -d /usr/local/bin
-
-      - name: Install necessary tools
-        run: make tools
-
-      - name: Run Acceptance test
-        run: |
-          make acceptance
+  acc-test:
+    uses: ./.github/workflows/reusable-dev-acc.yml
+    with:
+      test_case: ${{ inputs.test_case }}
+      test_description: ${{ inputs.test_description }}
+      test_case_folder: 'acc-testcases'
+    secrets:
+      DEV_HPEGL_IAM_SERVICE_URL: ${{ secrets.HPEGL_IAM_SERVICE_URL }}
+      DEV_HPEGL_TENANT_ID: ${{ secrets.HPEGL_TENANT_ID }}
+      DEV_HPEGL_USER_SECRET: ${{ secrets.HPEGL_USER_SECRET }}
+      DEV_HPEGL_USER_ID: ${{ secrets.HPEGL_USER_ID }}
+      DEV_HPEGL_VMAAS_API_URL: ${{ secrets.HPEGL_VMAAS_API_URL }}
+      DEV_HPEGL_VMAAS_LOCATION: ${{ secrets.HPEGL_VMAAS_LOCATION }}
+      DEV_HPEGL_VMAAS_SPACE_NAME: ${{ secrets.HPEGL_VMAAS_SPACE_NAME}}
+      TF_ACC: ${{ secrets.TF_ACC }}

--- a/.github/workflows/cicd-dev-acc.yml
+++ b/.github/workflows/cicd-dev-acc.yml
@@ -8,6 +8,7 @@ jobs:
     uses: ./.github/workflows/reusable-dev-acc.yml
     with:
       test_case: TestProvider
+      test_description: Check for valid terraform provider
     secrets: inherit
 
   test-datasouces:
@@ -17,6 +18,7 @@ jobs:
     uses: ./.github/workflows/reusable-dev-acc.yml
     with:
       test_case: TestAccDataSource
+      test_description: All data source test
     secrets: inherit
 
   test-vmaas-instance:
@@ -26,6 +28,7 @@ jobs:
     if: always()
     with:
       test_case: TestVmaasInstance TestAccResourceInstance
+      test_description: Instance test
     secrets: inherit
 
   test-vmaas-lb:
@@ -35,6 +38,7 @@ jobs:
     if: always()
     with:
       test_case: TestVmaasLB TestAccResourceLB TestVmaasLoadBalancerPlan TestAccResourceLoadBalancerCreate
+      test_description: Loadbalancer test
     secrets: inherit
 
   test-vmaas-network:
@@ -44,4 +48,5 @@ jobs:
     if: always()
     with:
       test_case: TestVmaasNetworkPlan TestAccResourceNetworkCreate TestAccResourceRouter TestVmaasRouter TestAccResourceTier TestVmaasRouteBGPNeighborPlan
+      test_description: Network test
     secrets: inherit

--- a/.github/workflows/cicd-dev-acc.yml
+++ b/.github/workflows/cicd-dev-acc.yml
@@ -11,50 +11,50 @@ jobs:
       test_description: Check for valid terraform provider
     secrets: inherit
 
-  # test-datasouces:
-  #   needs: 
-  #     - test-provider
-  #   if: "${{ needs.test-provider.result == 'success' }}"
-  #   uses: ./.github/workflows/reusable-dev-acc.yml
-  #   with:
-  #     test_case: TestAccDataSource
-  #     test_description: All data source test
-  #   secrets: inherit
+  test-datasouces:
+    needs: 
+      - test-provider
+    if: "always() && ${{ needs.test-provider.result == 'success' }}"
+    uses: ./.github/workflows/reusable-dev-acc.yml
+    with:
+      test_case: TestAccDataSource
+      test_description: All data source test
+    secrets: inherit
 
-  # test-vmaas-instance:
-  #   uses: ./.github/workflows/reusable-dev-acc.yml
-  #   needs: 
-  #     - test-datasouces
-  #   if: "${{ needs.test-provider.result == 'success' }}"
-  #   with:
-  #     test_case: TestVmaasInstance TestAccResourceInstance
-  #     test_description: Instance test
-  #   secrets: inherit
+  test-vmaas-instance:
+    uses: ./.github/workflows/reusable-dev-acc.yml
+    needs: 
+      - test-datasouces
+    if: "always() && ${{ needs.test-provider.result == 'success' }}"
+    with:
+      test_case: TestVmaasInstance TestAccResourceInstance
+      test_description: Instance test
+    secrets: inherit
 
-  # test-vmaas-lb:
-  #   uses: ./.github/workflows/reusable-dev-acc.yml
-  #   needs: 
-  #     - test-vmaas-instance
-  #   if: "${{ needs.test-provider.result == 'success' }}"
-  #   with:
-  #     test_case: TestVmaasLB TestAccResourceLB TestVmaasLoadBalancerPlan TestAccResourceLoadBalancerCreate
-  #     test_description: Loadbalancer test
-  #   secrets: inherit
+  test-vmaas-lb:
+    uses: ./.github/workflows/reusable-dev-acc.yml
+    needs: 
+      - test-vmaas-instance
+    if: "always() && ${{ needs.test-provider.result == 'success' }}"
+    with:
+      test_case: TestVmaasLB TestAccResourceLB TestVmaasLoadBalancerPlan TestAccResourceLoadBalancerCreate
+      test_description: Loadbalancer test
+    secrets: inherit
 
-  # test-vmaas-network:
-  #   uses: ./.github/workflows/reusable-dev-acc.yml
-  #   needs: 
-  #     - test-vmaas-lb
-  #   if: "${{ needs.test-provider.result == 'success' }}"
-  #   with:
-  #     test_case: TestVmaasNetworkPlan TestAccResourceNetworkCreate TestAccResourceRouter TestVmaasRouter TestAccResourceTier TestVmaasRouteBGPNeighborPlan
-  #     test_description: Network test
-  #   secrets: inherit
+  test-vmaas-network:
+    uses: ./.github/workflows/reusable-dev-acc.yml
+    needs: 
+      - test-vmaas-lb
+    if: "always() && ${{ needs.test-provider.result == 'success' }}"
+    with:
+      test_case: TestVmaasNetworkPlan TestAccResourceNetworkCreate TestAccResourceRouter TestVmaasRouter TestAccResourceTier TestVmaasRouteBGPNeighborPlan
+      test_description: Network test
+    secrets: inherit
 
   process-logs:
     runs-on: ubuntu-20.04
     needs:
-      - test-provider
+      - test-vmaas-network
     if: "always()"
     steps:
       - name: Checkout workspace

--- a/.github/workflows/cicd-dev-acc.yml
+++ b/.github/workflows/cicd-dev-acc.yml
@@ -25,41 +25,23 @@ jobs:
       - test-datasouces
     if: always()
     with:
-      test_case: TestVmaasInstance
+      test_case: TestVmaasInstance TestAccResourceInstance
     secrets: inherit
 
-  test-vmaas-resource-instance:
+  test-vmaas-lb:
     uses: ./.github/workflows/reusable-dev-acc.yml
     needs: 
       - test-vmaas-instance
     if: always()
     with:
-      test_case: TestAccResourceInstance
-    secrets: inherit 
-
-  test-vmaas-lb:
-    uses: ./.github/workflows/reusable-dev-acc.yml
-    needs: 
-      - test-vmaas-resource-instance
-    if: always()
-    with:
-      test_case: TestVmaasLB
+      test_case: TestVmaasLB TestAccResourceLB TestVmaasLoadBalancerPlan TestAccResourceLoadBalancerCreate
     secrets: inherit
 
-  test-vmaas-resource-lb:
+  test-vmaas-network:
     uses: ./.github/workflows/reusable-dev-acc.yml
     needs: 
       - test-vmaas-lb
     if: always()
     with:
-      test_case: TestAccResourceLB
-    secrets: inherit
-
-  test-vmaas-lb-plan:
-    uses: ./.github/workflows/reusable-dev-acc.yml
-    needs: 
-      - test-vmaas-resource-lb
-    if: always()
-    with:
-      test_case: "TestVmaasLoadBalancerPlan TestAccResourceLoadBalancerCreate"
+      test_case: TestVmaasNetworkPlan TestAccResourceNetworkCreate TestAccResourceRouter TestVmaasRouter TestAccResourceTier
     secrets: inherit

--- a/.github/workflows/cicd-dev-acc.yml
+++ b/.github/workflows/cicd-dev-acc.yml
@@ -1,4 +1,5 @@
 name: IaC Acceptance Tests for CI CD Dev Environment
+# This workflow runs all the acc-dev-testcases
 
 on:
   workflow_dispatch:

--- a/.github/workflows/cicd-dev-acc.yml
+++ b/.github/workflows/cicd-dev-acc.yml
@@ -13,7 +13,7 @@ jobs:
   test-datasouces:
     needs: 
       - test-provider
-    if: "${{ always() && needs.test-provider.result != 'failed' }}"
+    if: "${{ needs.test-provider.result != 'success' }}"
     uses: ./.github/workflows/dev-acc.yml
     with:
       test_case: TestAccDataSource

--- a/.github/workflows/cicd-dev-acc.yml
+++ b/.github/workflows/cicd-dev-acc.yml
@@ -23,8 +23,8 @@ jobs:
 
   test-vmaas-instance:
     uses: ./.github/workflows/reusable-dev-acc.yml
-    needs: [test-provider, test-datasouces]
-    if: "failure() || ${{ needs.test-provider.result == 'success' }}"
+    needs: [test-datasouces]
+    if: "always()"
     with:
       test_case: TestVmaasInstance TestAccResourceInstance
       test_description: Instance test
@@ -32,8 +32,8 @@ jobs:
 
   test-vmaas-lb:
     uses: ./.github/workflows/reusable-dev-acc.yml
-    needs: [test-provider, test-vmaas-instance]
-    if: "failure() || ${{ needs.test-provider.result == 'success' }}"
+    needs: [test-vmaas-instance]
+    if: "always()"
     with:
       test_case: TestVmaasLB TestAccResourceLB TestVmaasLoadBalancerPlan TestAccResourceLoadBalancerCreate
       test_description: Loadbalancer test
@@ -41,8 +41,8 @@ jobs:
 
   test-vmaas-network:
     uses: ./.github/workflows/reusable-dev-acc.yml
-    needs: [test-provider, test-vmaas-lb]
-    if: "failure() || ${{ needs.test-provider.result == 'success' }}"
+    needs: [test-vmaas-lb]
+    if: "always()"
     with:
       test_case: TestVmaasNetworkPlan TestAccResourceNetworkCreate TestAccResourceRouter TestVmaasRouter TestAccResourceTier TestVmaasRouteBGPNeighborPlan
       test_description: Network test

--- a/.github/workflows/cicd-dev-acc.yml
+++ b/.github/workflows/cicd-dev-acc.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   test-provider:
-    uses: ./.github/workflows/dev-acc.yml
+    uses: ./.github/workflows/reusable-dev-acc.yml
     with:
       test_case: TestProvider
     secrets: inherit
@@ -14,13 +14,13 @@ jobs:
     needs: 
       - test-provider
     if: "${{ needs.test-provider.result != 'success' }}"
-    uses: ./.github/workflows/dev-acc.yml
+    uses: ./.github/workflows/reusable-dev-acc.yml
     with:
       test_case: TestAccDataSource
     secrets: inherit
 
   test-vmaas-instance:
-    uses: ./.github/workflows/dev-acc.yml
+    uses: ./.github/workflows/reusable-dev-acc.yml
     with:
       test_case: TestVmaasInstance
     secrets: inherit

--- a/.github/workflows/cicd-dev-acc.yml
+++ b/.github/workflows/cicd-dev-acc.yml
@@ -43,5 +43,5 @@ jobs:
       - test-vmaas-lb
     if: always()
     with:
-      test_case: TestVmaasNetworkPlan TestAccResourceNetworkCreate TestAccResourceRouter TestVmaasRouter TestAccResourceTier
+      test_case: TestVmaasNetworkPlan TestAccResourceNetworkCreate TestAccResourceRouter TestVmaasRouter TestAccResourceTier TestVmaasRouteBGPNeighborPlan
     secrets: inherit

--- a/.github/workflows/cicd-dev-acc.yml
+++ b/.github/workflows/cicd-dev-acc.yml
@@ -50,3 +50,26 @@ jobs:
       test_case: TestVmaasNetworkPlan TestAccResourceNetworkCreate TestAccResourceRouter TestVmaasRouter TestAccResourceTier TestVmaasRouteBGPNeighborPlan
       test_description: Network test
     secrets: inherit
+
+  process-logs:
+    runs-on: ubuntu-20.04
+    needs:
+      - test-vmaas-network
+    if: "always()"
+    steps:
+      - name: Checkout workspace
+        uses: actions/checkout@v4
+      - name: Download logs
+        id: logs
+        uses: actions/download-artifact@v4
+        with:
+          path: tmp/artifacts
+          merge-multiple: true
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Print Result and Publish
+        run: | 
+          LOG_RESULT=$(python .github/parse_logs.py '${{ steps.logs.outputs.download-path }}')
+          echo $LOG_RESULT

--- a/.github/workflows/cicd-dev-acc.yml
+++ b/.github/workflows/cicd-dev-acc.yml
@@ -13,7 +13,7 @@ jobs:
   test-datasouces:
     needs: 
       - test-provider
-    if: "${{ needs.test-provider.result == 'success' }}"
+    if: "always() && ${{ needs.test-provider.result == 'success' }}"
     uses: ./.github/workflows/reusable-dev-acc.yml
     with:
       test_case: TestAccDataSource

--- a/.github/workflows/cicd-dev-acc.yml
+++ b/.github/workflows/cicd-dev-acc.yml
@@ -24,7 +24,7 @@ jobs:
   test-vmaas-instance:
     uses: ./.github/workflows/reusable-dev-acc.yml
     needs: [test-provider, test-datasouces]
-    if: "always() && ${{ needs.test-provider.result == 'success' }}"
+    if: "failure() || ${{ needs.test-provider.result == 'success' }}"
     with:
       test_case: TestVmaasInstance TestAccResourceInstance
       test_description: Instance test
@@ -33,7 +33,7 @@ jobs:
   test-vmaas-lb:
     uses: ./.github/workflows/reusable-dev-acc.yml
     needs: [test-provider, test-vmaas-instance]
-    if: "always() && ${{ needs.test-provider.result == 'success' }}"
+    if: "failure() || ${{ needs.test-provider.result == 'success' }}"
     with:
       test_case: TestVmaasLB TestAccResourceLB TestVmaasLoadBalancerPlan TestAccResourceLoadBalancerCreate
       test_description: Loadbalancer test
@@ -42,7 +42,7 @@ jobs:
   test-vmaas-network:
     uses: ./.github/workflows/reusable-dev-acc.yml
     needs: [test-provider, test-vmaas-lb]
-    if: "always() && ${{ needs.test-provider.result == 'success' }}"
+    if: "failure() || ${{ needs.test-provider.result == 'success' }}"
     with:
       test_case: TestVmaasNetworkPlan TestAccResourceNetworkCreate TestAccResourceRouter TestVmaasRouter TestAccResourceTier TestVmaasRouteBGPNeighborPlan
       test_description: Network test

--- a/.github/workflows/cicd-dev-acc.yml
+++ b/.github/workflows/cicd-dev-acc.yml
@@ -11,50 +11,50 @@ jobs:
       test_description: Check for valid terraform provider
     secrets: inherit
 
-  test-datasouces:
-    needs: 
-      - test-provider
-    if: "${{ needs.test-provider.result == 'success' }}"
-    uses: ./.github/workflows/reusable-dev-acc.yml
-    with:
-      test_case: TestAccDataSource
-      test_description: All data source test
-    secrets: inherit
+  # test-datasouces:
+  #   needs: 
+  #     - test-provider
+  #   if: "${{ needs.test-provider.result == 'success' }}"
+  #   uses: ./.github/workflows/reusable-dev-acc.yml
+  #   with:
+  #     test_case: TestAccDataSource
+  #     test_description: All data source test
+  #   secrets: inherit
 
-  test-vmaas-instance:
-    uses: ./.github/workflows/reusable-dev-acc.yml
-    needs: 
-      - test-datasouces
-    if: "${{ needs.test-provider.result == 'success' }}"
-    with:
-      test_case: TestVmaasInstance TestAccResourceInstance
-      test_description: Instance test
-    secrets: inherit
+  # test-vmaas-instance:
+  #   uses: ./.github/workflows/reusable-dev-acc.yml
+  #   needs: 
+  #     - test-datasouces
+  #   if: "${{ needs.test-provider.result == 'success' }}"
+  #   with:
+  #     test_case: TestVmaasInstance TestAccResourceInstance
+  #     test_description: Instance test
+  #   secrets: inherit
 
-  test-vmaas-lb:
-    uses: ./.github/workflows/reusable-dev-acc.yml
-    needs: 
-      - test-vmaas-instance
-    if: "${{ needs.test-provider.result == 'success' }}"
-    with:
-      test_case: TestVmaasLB TestAccResourceLB TestVmaasLoadBalancerPlan TestAccResourceLoadBalancerCreate
-      test_description: Loadbalancer test
-    secrets: inherit
+  # test-vmaas-lb:
+  #   uses: ./.github/workflows/reusable-dev-acc.yml
+  #   needs: 
+  #     - test-vmaas-instance
+  #   if: "${{ needs.test-provider.result == 'success' }}"
+  #   with:
+  #     test_case: TestVmaasLB TestAccResourceLB TestVmaasLoadBalancerPlan TestAccResourceLoadBalancerCreate
+  #     test_description: Loadbalancer test
+  #   secrets: inherit
 
-  test-vmaas-network:
-    uses: ./.github/workflows/reusable-dev-acc.yml
-    needs: 
-      - test-vmaas-lb
-    if: "${{ needs.test-provider.result == 'success' }}"
-    with:
-      test_case: TestVmaasNetworkPlan TestAccResourceNetworkCreate TestAccResourceRouter TestVmaasRouter TestAccResourceTier TestVmaasRouteBGPNeighborPlan
-      test_description: Network test
-    secrets: inherit
+  # test-vmaas-network:
+  #   uses: ./.github/workflows/reusable-dev-acc.yml
+  #   needs: 
+  #     - test-vmaas-lb
+  #   if: "${{ needs.test-provider.result == 'success' }}"
+  #   with:
+  #     test_case: TestVmaasNetworkPlan TestAccResourceNetworkCreate TestAccResourceRouter TestVmaasRouter TestAccResourceTier TestVmaasRouteBGPNeighborPlan
+  #     test_description: Network test
+  #   secrets: inherit
 
   process-logs:
     runs-on: ubuntu-20.04
     needs:
-      - test-vmaas-network
+      - test-provider
     if: "always()"
     steps:
       - name: Checkout workspace

--- a/.github/workflows/cicd-dev-acc.yml
+++ b/.github/workflows/cicd-dev-acc.yml
@@ -1,4 +1,4 @@
-name: IaC Acceptance Tests for CI CD Dev Environment
+name: IaC Tests for CI CD Gating Job
 # This workflow runs all the acc-dev-testcases
 
 on:
@@ -18,7 +18,7 @@ jobs:
     uses: ./.github/workflows/reusable-dev-acc.yml
     with:
       test_case: TestAccDataSource
-      test_description: All data source test
+      test_description: GET call usecase validations
     secrets: inherit
 
   test-vmaas-instance:
@@ -27,7 +27,7 @@ jobs:
     if: "always()"
     with:
       test_case: TestVmaasInstance TestAccResourceInstance
-      test_description: Instance test
+      test_description: Instance usecase validations
     secrets: inherit
 
   test-vmaas-lb:
@@ -36,7 +36,7 @@ jobs:
     if: "always()"
     with:
       test_case: TestVmaasLB TestAccResourceLB TestVmaasLoadBalancerPlan TestAccResourceLoadBalancerCreate
-      test_description: Loadbalancer test
+      test_description: Loadbalancer usecase validations
     secrets: inherit
 
   test-vmaas-network:
@@ -45,7 +45,7 @@ jobs:
     if: "always()"
     with:
       test_case: TestVmaasNetworkPlan TestAccResourceNetworkCreate TestAccResourceRouter TestVmaasRouter TestAccResourceTier TestVmaasRouteBGPNeighborPlan
-      test_description: Network test
+      test_description: NSX Network usecase validations
     secrets: inherit
 
   process-logs:
@@ -70,3 +70,4 @@ jobs:
         run: | 
           LOG_RESULT=$(python .github/parse_logs.py '${{ steps.logs.outputs.download-path }}')
           echo $LOG_RESULT
+          curl -X POST -H 'Content-type: application/json' --data "{'text':'CICD Terraform IaC Test results $LOG_RESULT and report link - https://github.com/HewlettPackard/hpegl-vmaas-terraform-resources/actions/runs/${{ github.run_id }}'}" '${{ secrets.TEAMS_URL_CICD }}' 

--- a/.github/workflows/cicd-dev-acc.yml
+++ b/.github/workflows/cicd-dev-acc.yml
@@ -25,7 +25,7 @@ jobs:
     uses: ./.github/workflows/reusable-dev-acc.yml
     needs: 
       - test-datasouces
-    if: always()
+    if: "always() && ${{ needs.test-provider.result == 'success' }}"
     with:
       test_case: TestVmaasInstance TestAccResourceInstance
       test_description: Instance test
@@ -35,7 +35,7 @@ jobs:
     uses: ./.github/workflows/reusable-dev-acc.yml
     needs: 
       - test-vmaas-instance
-    if: always()
+    if: "always() && ${{ needs.test-provider.result == 'success' }}"
     with:
       test_case: TestVmaasLB TestAccResourceLB TestVmaasLoadBalancerPlan TestAccResourceLoadBalancerCreate
       test_description: Loadbalancer test
@@ -45,7 +45,7 @@ jobs:
     uses: ./.github/workflows/reusable-dev-acc.yml
     needs: 
       - test-vmaas-lb
-    if: always()
+    if: "always() && ${{ needs.test-provider.result == 'success' }}"
     with:
       test_case: TestVmaasNetworkPlan TestAccResourceNetworkCreate TestAccResourceRouter TestVmaasRouter TestAccResourceTier TestVmaasRouteBGPNeighborPlan
       test_description: Network test

--- a/.github/workflows/cicd-dev-acc.yml
+++ b/.github/workflows/cicd-dev-acc.yml
@@ -1,4 +1,4 @@
-name: Dev Acceptance Tests for CI CD
+name: IaC Acceptance Tests for CI CD Dev Environment
 
 on:
   workflow_dispatch:
@@ -12,8 +12,7 @@ jobs:
     secrets: inherit
 
   test-datasouces:
-    needs: 
-      - test-provider
+    needs: [test-provider]
     if: "always() && ${{ needs.test-provider.result == 'success' }}"
     uses: ./.github/workflows/reusable-dev-acc.yml
     with:
@@ -23,8 +22,7 @@ jobs:
 
   test-vmaas-instance:
     uses: ./.github/workflows/reusable-dev-acc.yml
-    needs: 
-      - test-datasouces
+    needs: [test-provider, test-datasouces]
     if: "always() && ${{ needs.test-provider.result == 'success' }}"
     with:
       test_case: TestVmaasInstance TestAccResourceInstance
@@ -33,8 +31,7 @@ jobs:
 
   test-vmaas-lb:
     uses: ./.github/workflows/reusable-dev-acc.yml
-    needs: 
-      - test-vmaas-instance
+    needs: [test-provider, test-vmaas-instance]
     if: "always() && ${{ needs.test-provider.result == 'success' }}"
     with:
       test_case: TestVmaasLB TestAccResourceLB TestVmaasLoadBalancerPlan TestAccResourceLoadBalancerCreate
@@ -43,8 +40,7 @@ jobs:
 
   test-vmaas-network:
     uses: ./.github/workflows/reusable-dev-acc.yml
-    needs: 
-      - test-vmaas-lb
+    needs: [test-provider, test-vmaas-lb]
     if: "always() && ${{ needs.test-provider.result == 'success' }}"
     with:
       test_case: TestVmaasNetworkPlan TestAccResourceNetworkCreate TestAccResourceRouter TestVmaasRouter TestAccResourceTier TestVmaasRouteBGPNeighborPlan

--- a/.github/workflows/cicd-dev-acc.yml
+++ b/.github/workflows/cicd-dev-acc.yml
@@ -14,7 +14,7 @@ jobs:
   test-datasouces:
     needs: 
       - test-provider
-    if: "always() && ${{ needs.test-provider.result == 'success' }}"
+    if: "${{ needs.test-provider.result == 'success' }}"
     uses: ./.github/workflows/reusable-dev-acc.yml
     with:
       test_case: TestAccDataSource
@@ -25,7 +25,7 @@ jobs:
     uses: ./.github/workflows/reusable-dev-acc.yml
     needs: 
       - test-datasouces
-    if: "always() && ${{ needs.test-provider.result == 'success' }}"
+    if: "${{ needs.test-provider.result == 'success' }}"
     with:
       test_case: TestVmaasInstance TestAccResourceInstance
       test_description: Instance test
@@ -35,7 +35,7 @@ jobs:
     uses: ./.github/workflows/reusable-dev-acc.yml
     needs: 
       - test-vmaas-instance
-    if: "always() && ${{ needs.test-provider.result == 'success' }}"
+    if: "${{ needs.test-provider.result == 'success' }}"
     with:
       test_case: TestVmaasLB TestAccResourceLB TestVmaasLoadBalancerPlan TestAccResourceLoadBalancerCreate
       test_description: Loadbalancer test
@@ -45,7 +45,7 @@ jobs:
     uses: ./.github/workflows/reusable-dev-acc.yml
     needs: 
       - test-vmaas-lb
-    if: "always() && ${{ needs.test-provider.result == 'success' }}"
+    if: "${{ needs.test-provider.result == 'success' }}"
     with:
       test_case: TestVmaasNetworkPlan TestAccResourceNetworkCreate TestAccResourceRouter TestVmaasRouter TestAccResourceTier TestVmaasRouteBGPNeighborPlan
       test_description: Network test

--- a/.github/workflows/cicd-dev-acc.yml
+++ b/.github/workflows/cicd-dev-acc.yml
@@ -13,7 +13,7 @@ jobs:
   test-datasouces:
     needs: 
       - test-provider
-    if: "${{ needs.test-provider.result != 'success' }}"
+    if: "${{ needs.test-provider.result == 'success' }}"
     uses: ./.github/workflows/reusable-dev-acc.yml
     with:
       test_case: TestAccDataSource
@@ -21,6 +21,45 @@ jobs:
 
   test-vmaas-instance:
     uses: ./.github/workflows/reusable-dev-acc.yml
+    needs: 
+      - test-datasouces
+    if: always()
     with:
       test_case: TestVmaasInstance
+    secrets: inherit
+
+  test-vmaas-resource-instance:
+    uses: ./.github/workflows/reusable-dev-acc.yml
+    needs: 
+      - test-vmaas-instance
+    if: always()
+    with:
+      test_case: TestAccResourceInstance
+    secrets: inherit 
+
+  test-vmaas-lb:
+    uses: ./.github/workflows/reusable-dev-acc.yml
+    needs: 
+      - test-vmaas-resource-instance
+    if: always()
+    with:
+      test_case: TestVmaasLB
+    secrets: inherit
+
+  test-vmaas-resource-lb:
+    uses: ./.github/workflows/reusable-dev-acc.yml
+    needs: 
+      - test-vmaas-lb
+    if: always()
+    with:
+      test_case: TestAccResourceLB
+    secrets: inherit
+
+  test-vmaas-lb-plan:
+    uses: ./.github/workflows/reusable-dev-acc.yml
+    needs: 
+      - test-vmaas-resource-lb
+    if: always()
+    with:
+      test_case: "TestVmaasLoadBalancerPlan TestAccResourceLoadBalancerCreate"
     secrets: inherit

--- a/.github/workflows/cicd-prod-acc.yml
+++ b/.github/workflows/cicd-prod-acc.yml
@@ -1,4 +1,4 @@
-name: IaC Acceptance Tests for CI CD Prod Environment
+name: IaC Tests for CI CD Solution Job
 
 on:
   workflow_dispatch:
@@ -7,7 +7,7 @@ jobs:
   acc-test:
     uses: ./.github/workflows/reusable-dev-acc.yml
     with:
-      test_description: Check all Terraform Testcases
+      test_description: IaC Terraform Testcase
       test_case_folder: 'acc-testcases'
     secrets:
       DEV_HPEGL_IAM_SERVICE_URL: ${{ secrets.HPEGL_IAM_SERVICE_URL }}
@@ -41,3 +41,4 @@ jobs:
         run: | 
           LOG_RESULT=$(python .github/parse_logs.py '${{ steps.logs.outputs.download-path }}')
           echo $LOG_RESULT
+          curl -X POST -H 'Content-type: application/json' --data "{'text':'CICD Terraform IaC Test results $LOG_RESULT and report link - https://github.com/HewlettPackard/hpegl-vmaas-terraform-resources/actions/runs/${{ github.run_id }}'}" '${{ secrets.SLACK_URL_CICD }}'

--- a/.github/workflows/cicd-prod-acc.yml
+++ b/.github/workflows/cicd-prod-acc.yml
@@ -1,0 +1,43 @@
+name: IaC Acceptance Tests for CI CD Prod Environment
+
+on:
+  workflow_dispatch:
+
+jobs:
+  acc-test:
+    uses: ./.github/workflows/reusable-dev-acc.yml
+    with:
+      test_description: Check all Terraform Testcases
+      test_case_folder: 'acc-testcases'
+    secrets:
+      DEV_HPEGL_IAM_SERVICE_URL: ${{ secrets.HPEGL_IAM_SERVICE_URL }}
+      DEV_HPEGL_TENANT_ID: ${{ secrets.HPEGL_TENANT_ID }}
+      DEV_HPEGL_USER_SECRET: ${{ secrets.HPEGL_USER_SECRET }}
+      DEV_HPEGL_USER_ID: ${{ secrets.HPEGL_USER_ID }}
+      DEV_HPEGL_VMAAS_API_URL: ${{ secrets.HPEGL_VMAAS_API_URL }}
+      DEV_HPEGL_VMAAS_LOCATION: ${{ secrets.HPEGL_VMAAS_LOCATION }}
+      DEV_HPEGL_VMAAS_SPACE_NAME: ${{ secrets.HPEGL_VMAAS_SPACE_NAME}}
+      TF_ACC: ${{ secrets.TF_ACC }}
+  
+  process-logs:
+    runs-on: ubuntu-20.04
+    needs:
+      - acc-test
+    if: "always()"
+    steps:
+      - name: Checkout workspace
+        uses: actions/checkout@v4
+      - name: Download logs
+        id: logs
+        uses: actions/download-artifact@v4
+        with:
+          path: tmp/artifacts
+          merge-multiple: true
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Print Result and Publish
+        run: | 
+          LOG_RESULT=$(python .github/parse_logs.py '${{ steps.logs.outputs.download-path }}')
+          echo $LOG_RESULT

--- a/.github/workflows/dev-acc.yml
+++ b/.github/workflows/dev-acc.yml
@@ -50,8 +50,8 @@ jobs:
 
       - name: Run Acceptance test
         run: |
-          echo "Run Date: $(date +'%Y-%m-%d Time: %H:%M:%S %z' )" >> $LOG_FILE
-          for t in ${{ github.event.inputs.test_case }}; do export TF_ACC_TEST_PATH="$(pwd)/acc-dev-testcases" && make acceptance case="$t" >> $LOG_FILE; done
+          echo "Run Date: $(date +'%Y-%m-%d Time: %H:%M:%S %z' )" >> "$LOG_FILE"
+          for t in ${{ github.event.inputs.test_case }}; do export TF_ACC_TEST_PATH="$(pwd)/acc-dev-testcases" && make acceptance case="$t" >> "$LOG_FILE"; done
       
       - name: Print testcases output
         run: cat $LOG_FILE

--- a/.github/workflows/dev-acc.yml
+++ b/.github/workflows/dev-acc.yml
@@ -1,17 +1,17 @@
 name: Dev Acceptance Tests
 
-on:
-  # Runs every 2 days once at 3AM
-  # schedule:
-  #   - cron:  '0 21 */2 * *'
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
-      inputs:
-        test_case:
-          description: 'Enter testcase'     
-          required: false
-          default: ''
-          type: string
+# on:
+#   # Runs every 2 days once at 3AM
+#   # schedule:
+#   #   - cron:  '0 21 */2 * *'
+#   # Allows you to run this workflow manually from the Actions tab
+#   workflow_dispatch:
+inputs:
+  test_case:
+    description: 'Enter testcase'     
+    required: false
+    default: ''
+    type: string
 
   # release:
   #   types: [published]

--- a/.github/workflows/dev-acc.yml
+++ b/.github/workflows/dev-acc.yml
@@ -1,17 +1,17 @@
 name: Dev Acceptance Tests
 
-# on:
-#   # Runs every 2 days once at 3AM
-#   # schedule:
-#   #   - cron:  '0 21 */2 * *'
-#   # Allows you to run this workflow manually from the Actions tab
-#   workflow_dispatch:
-inputs:
-  test_case:
-    description: 'Enter testcase'     
-    required: false
-    default: ''
-    type: string
+on:
+  # Runs every 2 days once at 3AM
+  # schedule:
+  #   - cron:  '0 21 */2 * *'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_call:
+      inputs:
+        test_case:
+          description: 'Enter testcase'     
+          required: false
+          default: ''
+          type: string
 
   # release:
   #   types: [published]

--- a/.github/workflows/dev-acc.yml
+++ b/.github/workflows/dev-acc.yml
@@ -54,9 +54,11 @@ jobs:
           for t in ${{ github.event.inputs.test_case }}; do export TF_ACC_TEST_PATH="$(pwd)/acc-dev-testcases" && make acceptance case="$t" >> "$LOG_FILE"; done
       
       - name: Print testcases output
+        if: always()
         run: cat $LOG_FILE
   
       - name: Push the report to github artifacts
+        if: always()
         uses: actions/upload-artifact@v3
         with:
           name: "Terraform Test report- ${{ github.event.inputs.test_case }}"

--- a/.github/workflows/dev-acc.yml
+++ b/.github/workflows/dev-acc.yml
@@ -1,4 +1,4 @@
-name: Dev Acceptance Tests
+name: Dev Acceptance Testing for running an individual or all tests
 
 on:
   # Runs every 2 days once at 3AM
@@ -12,54 +12,24 @@ on:
           required: false
           default: ''
           type: string
+        test_description:
+          description: 'Enter description for the test'     
+          required: true
+          default: 'Check all Terraform Dev Testcases'
+          type: string
 
-  # release:
-  #   types: [published]
-env:
-  HPEGL_IAM_SERVICE_URL: ${{ secrets.DEV_HPEGL_IAM_SERVICE_URL }}
-  HPEGL_TENANT_ID: ${{ secrets.DEV_HPEGL_TENANT_ID }}
-  HPEGL_USER_SECRET: ${{ secrets.DEV_HPEGL_USER_SECRET }}
-  HPEGL_USER_ID: ${{ secrets.DEV_HPEGL_USER_ID }}
-  HPEGL_VMAAS_API_URL: ${{ secrets.DEV_HPEGL_VMAAS_API_URL }}
-  HPEGL_VMAAS_LOCATION: ${{ secrets.DEV_HPEGL_VMAAS_LOCATION }}
-  HPEGL_VMAAS_SPACE_NAME: ${{ secrets.DEV_HPEGL_VMAAS_SPACE_NAME}}
-  TF_ACC: ${{ secrets.TF_ACC }}
-  LOG_FILE: "Terraform_Logs.txt"
 jobs:
-  acc:
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        go: [ '1.17' ]
-    name: Dev Acceptance Tests
-    steps:
-      - name: Checkout workspace
-        uses: actions/checkout@v3
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.17
-      - name: Install dependencies
-        run: |
-          sudo apt-get install -y wget jq
-          wget https://releases.hashicorp.com/terraform/1.0.0/terraform_1.0.0_linux_amd64.zip
-          sudo unzip -fo terraform_1.0.0_linux_amd64.zip -d /usr/local/bin
-
-      - name: Install necessary tools
-        run: make tools
-
-      - name: Run Acceptance test
-        run: |
-          echo "Run Date: $(date +'%Y-%m-%d Time: %H:%M:%S %z' )" >> "$LOG_FILE"
-          for t in ${{ github.event.inputs.test_case }}; do export TF_ACC_TEST_PATH="$(pwd)/acc-dev-testcases" && make acceptance case="$t" >> "$LOG_FILE"; done
-      
-      - name: Print testcases output
-        if: always()
-        run: cat $LOG_FILE
-  
-      - name: Push the report to github artifacts
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: "Terraform Test report- ${{ github.event.inputs.test_case }}"
-          path: ${{ env.LOG_FILE }}
+  acc-test:
+    uses: ./.github/workflows/reusable-dev-acc.yml
+    with:
+      test_case: ${{ inputs.test_case }}
+      test_description: ${{ inputs.test_description }}
+    secrets:
+      DEV_HPEGL_IAM_SERVICE_URL: ${{ secrets.DEV_HPEGL_IAM_SERVICE_URL }}
+      DEV_HPEGL_TENANT_ID: ${{ secrets.DEV_HPEGL_TENANT_ID }}
+      DEV_HPEGL_USER_SECRET: ${{ secrets.DEV_HPEGL_USER_SECRET }}
+      DEV_HPEGL_USER_ID: ${{ secrets.DEV_HPEGL_USER_ID }}
+      DEV_HPEGL_VMAAS_API_URL: ${{ secrets.DEV_HPEGL_VMAAS_API_URL }}
+      DEV_HPEGL_VMAAS_LOCATION: ${{ secrets.DEV_HPEGL_VMAAS_LOCATION }}
+      DEV_HPEGL_VMAAS_SPACE_NAME: ${{ secrets.DEV_HPEGL_VMAAS_SPACE_NAME}}
+      TF_ACC: ${{ secrets.TF_ACC }}

--- a/.github/workflows/dev-acc.yml
+++ b/.github/workflows/dev-acc.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Run Acceptance test
         run: |
           echo "Run Date: $(date +'%Y-%m-%d Time: %H:%M:%S %z' )" >> $LOG_FILE
-          export TF_ACC_TEST_PATH="$(pwd)/acc-dev-testcases" && make acceptance case='${{ github.event.inputs.test_case }}' >> $LOG_FILE
+          for t in ${{ github.event.inputs.test_case }}; do export TF_ACC_TEST_PATH="$(pwd)/acc-dev-testcases" && make acceptance case="$t" >> $LOG_FILE; done
       
       - name: Print testcases output
         run: cat $LOG_FILE
@@ -59,5 +59,5 @@ jobs:
       - name: Push the report to github artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: "Terraform Test report: ${{ github.event.inputs.test_case }}"
+          name: "Terraform Test report- ${{ github.event.inputs.test_case }}"
           path: ${{ env.LOG_FILE }}

--- a/.github/workflows/dev-acc.yml
+++ b/.github/workflows/dev-acc.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
       inputs:
         test_case:
-          description: 'Enter testcase'     
+          description: 'Enter testcases sperated by space'     
           required: false
           default: ''
           type: string

--- a/.github/workflows/dev-acc.yml
+++ b/.github/workflows/dev-acc.yml
@@ -24,7 +24,7 @@ env:
   HPEGL_VMAAS_LOCATION: ${{ secrets.DEV_HPEGL_VMAAS_LOCATION }}
   HPEGL_VMAAS_SPACE_NAME: ${{ secrets.DEV_HPEGL_VMAAS_SPACE_NAME}}
   TF_ACC: ${{ secrets.TF_ACC }}
-  LOG_FILE: "${{ github.event.inputs.test_case }}Logs.txt"
+  LOG_FILE: "Terraform_Logs.txt"
 jobs:
   acc:
     runs-on: ubuntu-20.04

--- a/.github/workflows/dev-acc.yml
+++ b/.github/workflows/dev-acc.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
       inputs:
         test_case:
-          description: 'Enter testcases sperated by space'     
+          description: 'Enter testcases sperated by space. Leave empty for all'     
           required: false
           default: ''
           type: string

--- a/.github/workflows/dev-acc.yml
+++ b/.github/workflows/dev-acc.yml
@@ -1,4 +1,6 @@
-name: Dev Acceptance Testing for running an individual or all tests
+name: Dev Acceptance Testing
+# This workflow is intended to run a particular set of testcases
+# If want to execute all test, consider running cicd-dev-acc.yml
 
 on:
   # Runs every 2 days once at 3AM
@@ -8,14 +10,14 @@ on:
   workflow_dispatch:
       inputs:
         test_case:
-          description: 'Enter testcases sperated by space. Leave empty for all'     
-          required: false
-          default: ''
+          description: 'Enter testcases sperated by space'     
+          required: true
+          default: 'TestProvider'
           type: string
         test_description:
           description: 'Enter description for the test'     
           required: true
-          default: 'Check all Terraform Dev Testcases'
+          default: 'Check Terraform Dev Testcase'
           type: string
 
 jobs:

--- a/.github/workflows/reusable-dev-acc.yml
+++ b/.github/workflows/reusable-dev-acc.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           echo "Run Date: $(date +'%Y-%m-%d Time: %H:%M:%S %z' )" >> "$LOG_FILE"
           JOB_FAILED=false
-          if [ ${{ inputs.test_case }} != "" ]; then
+          if [[ -z "${{ inputs.test_case }}" ]]; then
             for t in ${{ inputs.test_case }}; do 
               if ! (export TF_ACC_TEST_PATH="$(pwd)/${{ inputs.test_case_folder }}" && make acceptance case="$t" >> "$LOG_FILE")
               then

--- a/.github/workflows/reusable-dev-acc.yml
+++ b/.github/workflows/reusable-dev-acc.yml
@@ -91,5 +91,10 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
+<<<<<<< HEAD
           name: "IaC Test Report - ${{ inputs.test_description }}"
           path: "${{ env.LOG_FILE }}"
+=======
+          name: "Terraform Test report ${{ github.run_id }} - ${{ inputs.test_case }}"
+          path: ${{ env.LOG_FILE }}
+>>>>>>> b0396e9 (improvement)

--- a/.github/workflows/reusable-dev-acc.yml
+++ b/.github/workflows/reusable-dev-acc.yml
@@ -43,7 +43,7 @@ env:
   HPEGL_VMAAS_LOCATION: ${{ secrets.DEV_HPEGL_VMAAS_LOCATION }}
   HPEGL_VMAAS_SPACE_NAME: ${{ secrets.DEV_HPEGL_VMAAS_SPACE_NAME}}
   TF_ACC: ${{ secrets.TF_ACC }}
-  LOG_FILE: "${{ github.event.inputs.test_case }}Terraform Log.txt"
+  LOG_FILE: "${{ inputs.test_case }}Terraform Log.txt"
 jobs:
   acc:
     runs-on: ubuntu-20.04

--- a/.github/workflows/reusable-dev-acc.yml
+++ b/.github/workflows/reusable-dev-acc.yml
@@ -71,7 +71,7 @@ jobs:
           echo "Run Date: $(date +'%Y-%m-%d Time: %H:%M:%S %z' )" >> "$LOG_FILE"
           JOB_FAILED=false
           for t in ${{ inputs.test_case }}; do 
-            if ! export TF_ACC_TEST_PATH="$(pwd)/acc-dev-testcases" && make acceptance case="$t" >> "$LOG_FILE"
+            if ! (export TF_ACC_TEST_PATH="$(pwd)/acc-dev-testcases" && make acceptance case="$t" >> "$LOG_FILE")
             then
               JOB_FAILED=true
               continue

--- a/.github/workflows/reusable-dev-acc.yml
+++ b/.github/workflows/reusable-dev-acc.yml
@@ -56,6 +56,10 @@ jobs:
     steps:
       - name: Checkout workspace
         uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -92,6 +96,10 @@ jobs:
       - name: Print testcases output
         if: always()
         run: cat "$LOG_FILE"
+
+      - name: Print testcases count
+        if: always()
+        run: python .github/parse_logs.py "$LOG_FILE"
   
       - name: Push the report to github artifacts
         if: always()

--- a/.github/workflows/reusable-dev-acc.yml
+++ b/.github/workflows/reusable-dev-acc.yml
@@ -1,4 +1,4 @@
-name: Reusable Dev Acceptance Tests
+name: Reusable Worflow for running Acceptance Tests. By default handles dev testing.
 
 on:
   workflow_call:
@@ -12,6 +12,11 @@ on:
         description: 'Enter description for the test'     
         required: true
         default: ''
+        type: string
+      test_case_folder:
+        description: 'Enter folder for test suite'     
+        required: false
+        default: 'acc-dev-testcases'
         type: string
     secrets:
       DEV_HPEGL_IAM_SERVICE_URL:
@@ -31,9 +36,6 @@ on:
       TF_ACC:
         required: true
 
-
-  # release:
-  #   types: [published]
 env:
   HPEGL_IAM_SERVICE_URL: ${{ secrets.DEV_HPEGL_IAM_SERVICE_URL }}
   HPEGL_TENANT_ID: ${{ secrets.DEV_HPEGL_TENANT_ID }}
@@ -72,7 +74,7 @@ jobs:
           echo "Run Date: $(date +'%Y-%m-%d Time: %H:%M:%S %z' )" >> "$LOG_FILE"
           JOB_FAILED=false
           for t in ${{ inputs.test_case }}; do 
-            if ! (export TF_ACC_TEST_PATH="$(pwd)/acc-dev-testcases" && make acceptance case="$t" >> "$LOG_FILE")
+            if ! (export TF_ACC_TEST_PATH="$(pwd)/${{ inputs.test_case_folder }}" && make acceptance case="$t" >> "$LOG_FILE")
             then
               JOB_FAILED=true
               continue

--- a/.github/workflows/reusable-dev-acc.yml
+++ b/.github/workflows/reusable-dev-acc.yml
@@ -8,7 +8,7 @@ on:
   workflow_call:
     inputs:
       test_case:
-        description: 'Enter testcase'     
+        description: 'Enter testcases sperated by space'     
         required: false
         default: ''
         type: string

--- a/.github/workflows/reusable-dev-acc.yml
+++ b/.github/workflows/reusable-dev-acc.yml
@@ -42,7 +42,7 @@ env:
   HPEGL_VMAAS_LOCATION: ${{ secrets.DEV_HPEGL_VMAAS_LOCATION }}
   HPEGL_VMAAS_SPACE_NAME: ${{ secrets.DEV_HPEGL_VMAAS_SPACE_NAME}}
   TF_ACC: ${{ secrets.TF_ACC }}
-  LOG_FILE: "${{ inputs.test_case }}Logs.txt"
+  LOG_FILE: "Terraform_Logs.txt"
 jobs:
   acc:
     runs-on: ubuntu-20.04

--- a/.github/workflows/reusable-dev-acc.yml
+++ b/.github/workflows/reusable-dev-acc.yml
@@ -73,7 +73,11 @@ jobs:
         run: |
           echo "Run Date: $(date +'%Y-%m-%d Time: %H:%M:%S %z' )" >> "$LOG_FILE"
           JOB_FAILED=false
+          
           if [[ -z "${{ inputs.test_case }}" ]]; then
+            export TF_ACC_TEST_PATH="$(pwd)/${{ inputs.test_case_folder }}" && make acceptance >> "$LOG_FILE"
+        
+          else
             for t in ${{ inputs.test_case }}; do 
               if ! (export TF_ACC_TEST_PATH="$(pwd)/${{ inputs.test_case_folder }}" && make acceptance case="$t" >> "$LOG_FILE")
               then
@@ -82,8 +86,6 @@ jobs:
               fi
             done
             if $JOB_FAILED; then  exit 1; fi 
-          else
-            export TF_ACC_TEST_PATH="$(pwd)/${{ inputs.test_case_folder }}" && make acceptance >> "$LOG_FILE"
           fi
           
       

--- a/.github/workflows/reusable-dev-acc.yml
+++ b/.github/workflows/reusable-dev-acc.yml
@@ -83,11 +83,11 @@ jobs:
       
       - name: Print testcases output
         if: always()
-        run: cat $LOG_FILE
+        run: cat "$LOG_FILE"
   
       - name: Push the report to github artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: "IaC Test Report - ${{ inputs.test_description }}"
-          path: ${{ env.LOG_FILE }}
+          path: "${{ env.LOG_FILE }}"

--- a/.github/workflows/reusable-dev-acc.yml
+++ b/.github/workflows/reusable-dev-acc.yml
@@ -9,7 +9,7 @@ on:
         default: ''
         type: string
       test_description:
-        description: 'Enter description for the testcases'     
+        description: 'Enter description for the test'     
         required: true
         default: ''
         type: string
@@ -53,9 +53,9 @@ jobs:
     name: Dev Acceptance Tests
     steps:
       - name: Checkout workspace
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: 1.17
       - name: Install dependencies
@@ -69,7 +69,6 @@ jobs:
 
       - name: Run Acceptance test
         run: |
-          echo $LOG_FILE
           echo "Run Date: $(date +'%Y-%m-%d Time: %H:%M:%S %z' )" >> "$LOG_FILE"
           JOB_FAILED=false
           for t in ${{ inputs.test_case }}; do 
@@ -88,7 +87,7 @@ jobs:
   
       - name: Push the report to github artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "IaC Test Report - ${{ inputs.test_description }}"
           path: ${{ env.LOG_FILE }}

--- a/.github/workflows/reusable-dev-acc.yml
+++ b/.github/workflows/reusable-dev-acc.yml
@@ -1,10 +1,6 @@
 name: Reusable Dev Acceptance Tests
 
 on:
-  # Runs every 2 days once at 3AM
-  # schedule:
-  #   - cron:  '0 21 */2 * *'
-  # Allows you to run this workflow manually from the Actions tab
   workflow_call:
     inputs:
       test_case:
@@ -47,7 +43,7 @@ env:
   HPEGL_VMAAS_LOCATION: ${{ secrets.DEV_HPEGL_VMAAS_LOCATION }}
   HPEGL_VMAAS_SPACE_NAME: ${{ secrets.DEV_HPEGL_VMAAS_SPACE_NAME}}
   TF_ACC: ${{ secrets.TF_ACC }}
-  LOG_FILE: "Terraform Log.txt"
+  LOG_FILE: "${{ github.event.inputs.test_case }}Terraform Log.txt"
 jobs:
   acc:
     runs-on: ubuntu-20.04
@@ -73,6 +69,7 @@ jobs:
 
       - name: Run Acceptance test
         run: |
+          echo $LOG_FILE
           echo "Run Date: $(date +'%Y-%m-%d Time: %H:%M:%S %z' )" >> "$LOG_FILE"
           JOB_FAILED=false
           for t in ${{ inputs.test_case }}; do 

--- a/.github/workflows/reusable-dev-acc.yml
+++ b/.github/workflows/reusable-dev-acc.yml
@@ -1,17 +1,35 @@
-name: Dev Acceptance Tests
+name: Reusable Dev Acceptance Tests
 
 on:
   # Runs every 2 days once at 3AM
   # schedule:
   #   - cron:  '0 21 */2 * *'
   # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
-      inputs:
-        test_case:
-          description: 'Enter testcase'     
-          required: false
-          default: ''
-          type: string
+  workflow_call:
+    inputs:
+      test_case:
+        description: 'Enter testcase'     
+        required: false
+        default: ''
+        type: string
+    secrets:
+      DEV_HPEGL_IAM_SERVICE_URL:
+        required: true
+      DEV_HPEGL_TENANT_ID:
+        required: true
+      DEV_HPEGL_USER_SECRET:
+        required: true
+      DEV_HPEGL_USER_ID:
+        required: true
+      DEV_HPEGL_VMAAS_API_URL:
+        required: true
+      DEV_HPEGL_VMAAS_LOCATION:
+        required: true
+      DEV_HPEGL_VMAAS_SPACE_NAME:
+        required: true
+      TF_ACC:
+        required: true
+
 
   # release:
   #   types: [published]
@@ -24,7 +42,7 @@ env:
   HPEGL_VMAAS_LOCATION: ${{ secrets.DEV_HPEGL_VMAAS_LOCATION }}
   HPEGL_VMAAS_SPACE_NAME: ${{ secrets.DEV_HPEGL_VMAAS_SPACE_NAME}}
   TF_ACC: ${{ secrets.TF_ACC }}
-  LOG_FILE: "${{ github.event.inputs.test_case }}Logs.txt"
+  LOG_FILE: "${{ inputs.test_case }}Logs.txt"
 jobs:
   acc:
     runs-on: ubuntu-20.04
@@ -51,7 +69,7 @@ jobs:
       - name: Run Acceptance test
         run: |
           echo "Run Date: $(date +'%Y-%m-%d Time: %H:%M:%S %z' )" >> $LOG_FILE
-          export TF_ACC_TEST_PATH="$(pwd)/acc-dev-testcases" && make acceptance case='${{ github.event.inputs.test_case }}' >> $LOG_FILE
+          export TF_ACC_TEST_PATH="$(pwd)/acc-dev-testcases" && make acceptance case='${{ inputs.test_case }}' >> $LOG_FILE
       
       - name: Print testcases output
         run: cat $LOG_FILE
@@ -59,5 +77,5 @@ jobs:
       - name: Push the report to github artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: "Terraform Test report: ${{ github.event.inputs.test_case }}"
+          name: "Terraform Test report: ${{ inputs.test_case }}"
           path: ${{ env.LOG_FILE }}

--- a/.github/workflows/reusable-dev-acc.yml
+++ b/.github/workflows/reusable-dev-acc.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         go: [ '1.17' ]
-    name: Dev Acceptance Tests
+    name: Acceptance Test Job
     steps:
       - name: Checkout workspace
         uses: actions/checkout@v4

--- a/.github/workflows/reusable-dev-acc.yml
+++ b/.github/workflows/reusable-dev-acc.yml
@@ -12,6 +12,11 @@ on:
         required: false
         default: ''
         type: string
+      test_description:
+        description: 'Enter description for the testcases'     
+        required: true
+        default: ''
+        type: string
     secrets:
       DEV_HPEGL_IAM_SERVICE_URL:
         required: true
@@ -42,7 +47,7 @@ env:
   HPEGL_VMAAS_LOCATION: ${{ secrets.DEV_HPEGL_VMAAS_LOCATION }}
   HPEGL_VMAAS_SPACE_NAME: ${{ secrets.DEV_HPEGL_VMAAS_SPACE_NAME}}
   TF_ACC: ${{ secrets.TF_ACC }}
-  LOG_FILE: "Terraform_Logs.txt"
+  LOG_FILE: "Terraform Log.txt"
 jobs:
   acc:
     runs-on: ubuntu-20.04
@@ -88,5 +93,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: "Terraform Test report ${{ github.run_id }} - ${{ inputs.test_case }}"
+          name: "IaC Test Report - ${{ inputs.test_description }}"
           path: ${{ env.LOG_FILE }}

--- a/.github/workflows/reusable-dev-acc.yml
+++ b/.github/workflows/reusable-dev-acc.yml
@@ -68,8 +68,8 @@ jobs:
 
       - name: Run Acceptance test
         run: |
-          echo "Run Date: $(date +'%Y-%m-%d Time: %H:%M:%S %z' )" >> $LOG_FILE
-          for t in ${{ inputs.test_case }}; do export TF_ACC_TEST_PATH="$(pwd)/acc-dev-testcases" && make acceptance case="$t" >> $LOG_FILE; done
+          echo "Run Date: $(date +'%Y-%m-%d Time: %H:%M:%S %z' )" >> "$LOG_FILE"
+          for t in ${{ inputs.test_case }}; do export TF_ACC_TEST_PATH="$(pwd)/acc-dev-testcases" && make acceptance case="$t" >> "$LOG_FILE"; done
           
       
       - name: Print testcases output

--- a/.github/workflows/reusable-dev-acc.yml
+++ b/.github/workflows/reusable-dev-acc.yml
@@ -73,14 +73,18 @@ jobs:
         run: |
           echo "Run Date: $(date +'%Y-%m-%d Time: %H:%M:%S %z' )" >> "$LOG_FILE"
           JOB_FAILED=false
-          for t in ${{ inputs.test_case }}; do 
-            if ! (export TF_ACC_TEST_PATH="$(pwd)/${{ inputs.test_case_folder }}" && make acceptance case="$t" >> "$LOG_FILE")
-            then
-              JOB_FAILED=true
-              continue
-            fi
-          done
-          if $JOB_FAILED; then  exit 1; fi 
+          if [ ${{ inputs.test_case }} != "" ]; then
+            for t in ${{ inputs.test_case }}; do 
+              if ! (export TF_ACC_TEST_PATH="$(pwd)/${{ inputs.test_case_folder }}" && make acceptance case="$t" >> "$LOG_FILE")
+              then
+                JOB_FAILED=true
+                continue
+              fi
+            done
+            if $JOB_FAILED; then  exit 1; fi 
+          else
+            export TF_ACC_TEST_PATH="$(pwd)/${{ inputs.test_case_folder }}" && make acceptance >> "$LOG_FILE"
+          fi
           
       
       - name: Print testcases output

--- a/.github/workflows/reusable-dev-acc.yml
+++ b/.github/workflows/reusable-dev-acc.yml
@@ -69,7 +69,8 @@ jobs:
       - name: Run Acceptance test
         run: |
           echo "Run Date: $(date +'%Y-%m-%d Time: %H:%M:%S %z' )" >> $LOG_FILE
-          export TF_ACC_TEST_PATH="$(pwd)/acc-dev-testcases" && make acceptance case='${{ inputs.test_case }}' >> $LOG_FILE
+          for t in ${{ inputs.test_case }}; do export TF_ACC_TEST_PATH="$(pwd)/acc-dev-testcases" && make acceptance case="$t" >> $LOG_FILE; done
+          
       
       - name: Print testcases output
         run: cat $LOG_FILE
@@ -77,5 +78,5 @@ jobs:
       - name: Push the report to github artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: "Terraform Test report: ${{ inputs.test_case }}"
+          name: "Terraform Test report- ${{ inputs.test_case }}"
           path: ${{ env.LOG_FILE }}

--- a/.github/workflows/reusable-dev-acc.yml
+++ b/.github/workflows/reusable-dev-acc.yml
@@ -69,7 +69,15 @@ jobs:
       - name: Run Acceptance test
         run: |
           echo "Run Date: $(date +'%Y-%m-%d Time: %H:%M:%S %z' )" >> "$LOG_FILE"
-          for t in ${{ inputs.test_case }}; do export TF_ACC_TEST_PATH="$(pwd)/acc-dev-testcases" && make acceptance case="$t" >> "$LOG_FILE"; done
+          JOB_FAILED=false
+          for t in ${{ inputs.test_case }}; do 
+            if ! export TF_ACC_TEST_PATH="$(pwd)/acc-dev-testcases" && make acceptance case="$t" >> "$LOG_FILE"
+            then
+              JOB_FAILED=true
+              continue
+            fi
+          done
+          if $JOB_FAILED; then  exit 1; fi 
           
       
       - name: Print testcases output
@@ -80,5 +88,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: "Terraform Test report- ${{ inputs.test_case }}"
+          name: "Terraform Test report ${{ github.run_id }} - ${{ inputs.test_case }}"
           path: ${{ env.LOG_FILE }}

--- a/.github/workflows/reusable-dev-acc.yml
+++ b/.github/workflows/reusable-dev-acc.yml
@@ -73,9 +73,11 @@ jobs:
           
       
       - name: Print testcases output
+        if: always()
         run: cat $LOG_FILE
   
       - name: Push the report to github artifacts
+        if: always()
         uses: actions/upload-artifact@v3
         with:
           name: "Terraform Test report- ${{ inputs.test_case }}"

--- a/.github/workflows/reusable-dev-acc.yml
+++ b/.github/workflows/reusable-dev-acc.yml
@@ -91,10 +91,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-<<<<<<< HEAD
           name: "IaC Test Report - ${{ inputs.test_description }}"
           path: "${{ env.LOG_FILE }}"
-=======
-          name: "Terraform Test report ${{ github.run_id }} - ${{ inputs.test_case }}"
-          path: ${{ env.LOG_FILE }}
->>>>>>> b0396e9 (improvement)

--- a/.github/workflows/reusable-dev-acc.yml
+++ b/.github/workflows/reusable-dev-acc.yml
@@ -43,7 +43,7 @@ env:
   HPEGL_VMAAS_LOCATION: ${{ secrets.DEV_HPEGL_VMAAS_LOCATION }}
   HPEGL_VMAAS_SPACE_NAME: ${{ secrets.DEV_HPEGL_VMAAS_SPACE_NAME}}
   TF_ACC: ${{ secrets.TF_ACC }}
-  LOG_FILE: "${{ inputs.test_case }}Terraform Log.txt"
+  LOG_FILE: "Terraform Log - ${{ inputs.test_description }}.txt"
 jobs:
   acc:
     runs-on: ubuntu-20.04

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ coverage: vendor
 ACC_TEST_FILE_LOCATION=github.com/HewlettPackard/hpegl-vmaas-terraform-resources/internal/acceptance_test
 acceptance:
 	@if [ "${case}" != "" ]; then \
-		TF_ACC=true go test -run $(case) -v -timeout=2000s -cover $(ACC_TEST_FILE_LOCATION); \
+		TF_ACC=true go test -run $(case) -v -timeout=20000s -cover $(ACC_TEST_FILE_LOCATION); \
 	else \
 		TF_ACC=true go test -v -timeout=50000s -cover $(ACC_TEST_FILE_LOCATION) -parallel 1;\
 	fi

--- a/acc-testcases/data-sources/network_type.yaml
+++ b/acc-testcases/data-sources/network_type.yaml
@@ -1,3 +1,3 @@
 acc:
 - config: |
-    name = "NSX Segment"
+    name = "NSX-T Segment"

--- a/acc-testcases/data-sources/network_type.yaml
+++ b/acc-testcases/data-sources/network_type.yaml
@@ -1,3 +1,3 @@
 acc:
 - config: |
-    name = "NSX-T Segment"
+    name = "NSX Segment"


### PR DESCRIPTION
This PR adds changes for dev acceptance testing workflow. Now user can run specific set of testcase for Dev testing. The terraform logs are attached as artifacts for further reference.
Additionally, CI CD workflow has been added to test all the dev acceptance test.

Note: Github actions doesn't allow any individual workflow to be longer than 6hrs, hence the testcases were broken down.

Test workflows:
https://github.com/HewlettPackard/hpegl-vmaas-terraform-resources/actions/runs/7276501128
https://github.com/HewlettPackard/hpegl-vmaas-terraform-resources/actions/runs/7284337277