### PR TITLE
Updated Acceptance Test

### DIFF
--- a/.github/workflows/acc.yml
+++ b/.github/workflows/acc.yml
@@ -2,8 +2,8 @@ name: Acceptance Tests
 
 on:
   # Runs every 2 days once at 3AM
-  schedule:
-    - cron:  '0 21 */2 * *'
+  # schedule:
+  #   - cron:  '0 21 */2 * *'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
       inputs:


### PR DESCRIPTION
Removed on schedule run, cause cicd triggers cicd-prod-acc.yml which is similar to acc.yml

Ref: https://github.com/hpe-hcss/vmaas-cmp-tests/pull/288 
New Schedule run Workflow: https://github.com/HewlettPackard/hpegl-vmaas-terraform-resources/actions/workflows/cicd-prod-acc.yml
Workflow Triggered by: https://github.com/hpe-hcss/vmaas-cmp-tests/actions/workflows/pce_solution_workflow.yml