### PR TITLE
Fix-up docs templates

### DIFF
--- a/templates/resources/vmaas_dhcp_server.md.tmpl
+++ b/templates/resources/vmaas_dhcp_server.md.tmpl
@@ -3,7 +3,7 @@ layout: ""
 page_title: "hpegl_vmaas_dhcp_server Resource - vmaas-terraform-resources"
 subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
 description: |-
-  {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
 -> Compatible version >= 5.2.13

--- a/templates/resources/vmaas_instance.md.tmpl
+++ b/templates/resources/vmaas_instance.md.tmpl
@@ -3,7 +3,7 @@ layout: ""
 page_title: "hpegl_vmaas_instance Resource - vmaas-terraform-resources"
 subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
 description: |-
-  {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
 -> Compatible version >= 5.2.4

--- a/templates/resources/vmaas_instance_clone.md.tmpl
+++ b/templates/resources/vmaas_instance_clone.md.tmpl
@@ -3,7 +3,7 @@ layout: ""
 page_title: "hpegl_vmaas_instance_clone Resource - vmaas-terraform-resources-clone"
 subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
 description: |-
-  {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
 -> Compatible version >= 5.2.4

--- a/templates/resources/vmaas_load_balancer.md.tmpl
+++ b/templates/resources/vmaas_load_balancer.md.tmpl
@@ -3,7 +3,7 @@ layout: ""
 page_title: "hpegl_vmaas_load_balancer Resource - vmaas-terraform-resources"
 subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
 description: |-
-  {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
 # Resource hpegl_vmaas_load_balancer

--- a/templates/resources/vmaas_load_balancer_monitor.md.tmpl
+++ b/templates/resources/vmaas_load_balancer_monitor.md.tmpl
@@ -3,7 +3,7 @@ layout: ""
 page_title: "hpegl_vmaas_load_balancer_monitor Resource - vmaas-terraform-resources"
 subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
 description: |-
-  {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
 # Resource hpegl_vmaas_load_balancer_monitor

--- a/templates/resources/vmaas_load_balancer_pool.md.tmpl
+++ b/templates/resources/vmaas_load_balancer_pool.md.tmpl
@@ -3,7 +3,7 @@ layout: ""
 page_title: "hpegl_vmaas_load_balancer_pool Resource - vmaas-terraform-resources"
 subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
 description: |-
-  {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
 # Resource hpegl_vmaas_load_balancer_pool

--- a/templates/resources/vmaas_load_balancer_profile.md.tmpl
+++ b/templates/resources/vmaas_load_balancer_profile.md.tmpl
@@ -3,7 +3,7 @@ layout: ""
 page_title: "hpegl_vmaas_load_balancer_profile Resource - vmaas-terraform-resources"
 subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
 description: |-
-  {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
 # Resource hpegl_vmaas_load_balancer_profile

--- a/templates/resources/vmaas_load_balancer_virtual_server.md.tmpl
+++ b/templates/resources/vmaas_load_balancer_virtual_server.md.tmpl
@@ -3,7 +3,7 @@ layout: ""
 page_title: "hpegl_vmaas_load_balancer_virtual_server Resource - vmaas-terraform-resources"
 subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
 description: |-
-  {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
 # Resource hpegl_vmaas_load_balancer_virtual_server

--- a/templates/resources/vmaas_network.md.tmpl
+++ b/templates/resources/vmaas_network.md.tmpl
@@ -3,7 +3,7 @@ layout: ""
 page_title: "hpegl_vmaas_network Resource - vmaas-terraform-resources"
 subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
 description: |-
-  {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
 -> Compatible version >= 5.2.13

--- a/templates/resources/vmaas_router.md.tmpl
+++ b/templates/resources/vmaas_router.md.tmpl
@@ -3,7 +3,7 @@ layout: ""
 page_title: "hpegl_vmaas_router Resource - vmaas-terraform-resources"
 subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
 description: |-
-  {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
 # Resource hpegl_vmaas_router

--- a/templates/resources/vmaas_router_bgp_neighbor.tmpl
+++ b/templates/resources/vmaas_router_bgp_neighbor.tmpl
@@ -3,7 +3,7 @@ layout: ""
 page_title: "hpegl_vmaas_router_bgp_neighbor Resource - vmaas-terraform-resources"
 subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
 description: |-
-  {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
 -> Compatible version >= 5.2.12

--- a/templates/resources/vmaas_router_firewall_rule_group.md.tmpl
+++ b/templates/resources/vmaas_router_firewall_rule_group.md.tmpl
@@ -3,7 +3,7 @@ layout: ""
 page_title: "hpegl_vmaas_router_firewall_rule_group Resource - vmaas-terraform-resources"
 subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
 description: |-
-  {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
 -> Compatible version >= 5.2.12

--- a/templates/resources/vmaas_router_nat_rule.md.tmpl
+++ b/templates/resources/vmaas_router_nat_rule.md.tmpl
@@ -3,7 +3,7 @@ layout: ""
 page_title: "hpegl_vmaas_router_nat_rule Resource - vmaas-terraform-resources"
 subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
 description: |-
-  {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
 -> Compatible version >= 5.2.10

--- a/templates/resources/vmaas_router_route.md.tmpl
+++ b/templates/resources/vmaas_router_route.md.tmpl
@@ -3,7 +3,7 @@ layout: ""
 page_title: "hpegl_vmaas_router_route Resource - vmaas-terraform-resources"
 subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
 description: |-
-  {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
 -> Compatible version >= 5.2.12


### PR DESCRIPTION
We've updated the version of tfplugin-docs which has exposed issues with the existing resource templates.  As a result of a change in indentation in the generated "description" field of the the .md files resulting from the resource templates the documentation wasn't being categorised correctly on the provider registry landing page.  To fix this we make the following change in each template:

  {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}

becomes

{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}